### PR TITLE
[Feat] Customer service center Page

### DIFF
--- a/app/(help)/help/components/faqDropdown.tsx
+++ b/app/(help)/help/components/faqDropdown.tsx
@@ -1,0 +1,82 @@
+"use client";
+
+import React, { useState } from "react";
+import Image from "next/image";
+import keyboardArrowDown from "@/images/icon/keyboardArrowDown.svg";
+import keyboardArrowUp from "@/images/icon/keyboardArrowUp.svg";
+import polygon from "@/images/icon/polygon_4.svg";
+import { profileImageMap } from "@/utils/mappingProfile";
+import Alert from "@/components/alert/alert";
+import { SystemFaqData } from "@/types/service";
+
+interface FaqDropdownProps {
+  data: SystemFaqData;
+  isOpen: boolean;
+  setSelected: (value: number | null) => void;
+}
+
+const FaqDropdown = ({ data, isOpen, setSelected }: FaqDropdownProps) => {
+  const [alertMessage, setAlertMessage] = useState<string | null>(null);
+
+  const onClick = (id: number) => {
+    setSelected(isOpen ? null : id);
+  };
+
+  return (
+    <div className="flex flex-col gap-4 justify-start items-start pt-4 pb-2.5 pl-4 pr-3 md:px-6 md:py-[26px] bg-background rounded-[8px] md:gap-8">
+      <div className="w-full justify-between items-center md:flex">
+        <div className="w-[62px] h-[24px] flex items-center justify-center mr-10 rounded-[4px] text-mobile_body3_m text-center mb-2.5 md:mb-0 md:w-[66px] md:h-[28px] md:text-body3_m bg-selectedoption_hover text-primary shrink-0">
+          FAQ
+        </div>
+        <div className="w-full flex justify-between items-center md:flex">
+          <div className="text-text1 text-mobile_body1_m md:text-h4">
+            {data.title}
+          </div>
+          <button
+            className="flex justify-center items-center p-0.5 cursor-pointer"
+            onClick={() => onClick(data.id)}
+          >
+            <Image
+              src={isOpen ? keyboardArrowUp : keyboardArrowDown}
+              alt="arrow"
+              width={28}
+              height={28}
+            />
+          </button>
+        </div>
+      </div>
+
+      {isOpen && (
+        <div className="w-full flex-col justify-start items-start gap-8 flex">
+          <div className="w-full items-start gap-8 flex md:pl-1">
+            <Image
+              src={profileImageMap["ARIARI_MONKEY"]}
+              alt="club_img"
+              width={56}
+              height={56}
+              className="hidden md:block rounded-full"
+            />
+            <div className="w-full flex justify-start items-start relative">
+              <Image
+                src={polygon}
+                alt="polygon"
+                width={34}
+                height={30.5}
+                className="hidden absolute left-[-16px] top-[8px] md:block"
+              />
+              <div className="w-full flex p-3 bg-hover rounded-[12px] justify-start items-center text-subtext2 text-mobile_body1_r md:body1_r md:p-6">
+                {data.body}
+              </div>
+            </div>
+          </div>
+        </div>
+      )}
+
+      {alertMessage && (
+        <Alert text={alertMessage} onClose={() => setAlertMessage(null)} />
+      )}
+    </div>
+  );
+};
+
+export default FaqDropdown;

--- a/app/(help)/help/components/mobileHeaderSection.tsx
+++ b/app/(help)/help/components/mobileHeaderSection.tsx
@@ -12,7 +12,7 @@ const MobileHeaderSection = () => {
   };
 
   return (
-    <div className="md:hidden flex flex-row justify-between mt-[46px] mb-5">
+    <div className="flex flex-row justify-between mt-[46px] mb-5">
       <div className="flex gap-2">
         <Image
           src={vector}
@@ -20,7 +20,7 @@ const MobileHeaderSection = () => {
           width={24}
           height={24}
           onClick={handleGoBack}
-          className="md:hidden cursor-pointer"
+          className="cursor-pointer"
         />
         <h1 className="text-text1 text-mobile_h1_contents_title">고객센터</h1>
       </div>

--- a/app/(help)/help/components/noticeDropdown.tsx
+++ b/app/(help)/help/components/noticeDropdown.tsx
@@ -24,6 +24,7 @@ interface NoticeDropdownProps {
   isFirstPin?: boolean;
   isLastPin?: boolean;
   isSinglePin?: boolean;
+  index: number;
 }
 
 const NoticeDropdown = ({
@@ -34,6 +35,7 @@ const NoticeDropdown = ({
   isFirstPin,
   isLastPin,
   isSinglePin,
+  index,
 }: NoticeDropdownProps) => {
   const menuRef = useRef<HTMLDivElement>(null);
   const [currentImageIndex, setCurrentImageIndex] = useState<number>(0);
@@ -109,7 +111,7 @@ const NoticeDropdown = ({
         <div className="flex w-full justify-between">
           <div className="flex items-center gap-6">
             <p className="w-[66px] text-center md:block hidden text-subtext2 text-mobile_body3_r">
-              {notice.id}
+              {index + 1}
             </p>
             <div className="flex items-center gap-1 md:gap-2">
               <h1 className="text-text1 text-mobile_body1_m md:text-h4">

--- a/app/(help)/help/components/noticeDropdown.tsx
+++ b/app/(help)/help/components/noticeDropdown.tsx
@@ -1,0 +1,218 @@
+import Image from "next/image";
+import { useCallback, useEffect, useRef, useState } from "react";
+import { useSwipeable } from "react-swipeable";
+import vector from "@/images/icon/pullDown.svg";
+import noti from "@/images/icon/notice.svg";
+import empty from "@/images/icon/empty_img.svg";
+import Alert from "@/components/alert/alert";
+import RoundVectorBtn from "@/components/button/iconBtn/roundVectorBtn";
+
+import { format } from "date-fns";
+
+interface NoticeDropdownProps {
+  notice: {
+    id: number;
+    title: string;
+    body: string;
+    createdDateTime: string;
+    imageUrls?: string[];
+    userName?: string;
+  };
+  isOpen: boolean;
+  setOpenDropdownId: (id: number | null) => void;
+  pin: boolean;
+  isFirstPin?: boolean;
+  isLastPin?: boolean;
+  isSinglePin?: boolean;
+}
+
+const NoticeDropdown = ({
+  notice,
+  isOpen,
+  setOpenDropdownId,
+  pin,
+  isFirstPin,
+  isLastPin,
+  isSinglePin,
+}: NoticeDropdownProps) => {
+  const menuRef = useRef<HTMLDivElement>(null);
+  const [currentImageIndex, setCurrentImageIndex] = useState<number>(0);
+  const [isOpenOption, setIsOpenOption] = useState<boolean>(false);
+  const [alertMessage, setAlertMessage] = useState<string | null>(null);
+
+  const handleVectorClick = useCallback(() => {
+    setOpenDropdownId(isOpen ? null : notice.id);
+  }, [isOpen, notice.id, setOpenDropdownId]);
+
+  const isFirstSlide = currentImageIndex === 0;
+  const isLastSlide =
+    (notice.imageUrls?.length || 0) > 0 &&
+    currentImageIndex === (notice.imageUrls?.length || 0) - 1;
+
+  const handlers = useSwipeable({
+    onSwipedLeft: () =>
+      setCurrentImageIndex((prev) =>
+        prev < (notice.imageUrls?.length || 0) - 1 ? prev + 1 : prev
+      ),
+    onSwipedRight: () =>
+      setCurrentImageIndex((prev) => (prev > 0 ? prev - 1 : prev)),
+    preventScrollOnSwipe: true,
+    trackTouch: true,
+    trackMouse: true,
+    delta: 10,
+  });
+
+  useEffect(() => {
+    if (!isOpen) {
+      setCurrentImageIndex(0);
+    }
+  }, [isOpen]);
+
+  const handleSliderPrevClick = () => {
+    if (!isFirstSlide) setCurrentImageIndex((prev) => prev - 1);
+  };
+
+  const handleSliderNextClick = () => {
+    if (!isLastSlide) setCurrentImageIndex((prev) => prev + 1);
+  };
+
+  useEffect(() => {
+    const handleClickOutside = (event: MouseEvent) => {
+      if (menuRef.current && !menuRef.current.contains(event.target as Node)) {
+        setIsOpenOption(false);
+      }
+    };
+    if (isOpenOption) {
+      document.addEventListener("mousedown", handleClickOutside);
+    }
+    return () => {
+      document.removeEventListener("mousedown", handleClickOutside);
+    };
+  }, [isOpenOption]);
+
+  return (
+    <div
+      className={`bg-background p-4 md:py-[26px] md:px-6 
+      ${
+        pin
+          ? isSinglePin
+            ? "rounded-lg"
+            : isFirstPin
+            ? "rounded-t-lg"
+            : isLastPin
+            ? "rounded-b-lg"
+            : ""
+          : "rounded-lg"
+      }`}
+    >
+      <div className="flex flex-col gap-3.5 md:flex-row justify-between">
+        <div className="flex w-full justify-between">
+          <div className="flex items-center gap-6">
+            <p className="w-[66px] text-center md:block hidden text-subtext2 text-mobile_body3_r">
+              {notice.id}
+            </p>
+            <div className="flex items-center gap-1 md:gap-2">
+              <h1 className="text-text1 text-mobile_body1_m md:text-h4">
+                {notice.title}
+              </h1>
+              {notice.imageUrls && notice.imageUrls.length > 0 && (
+                <Image
+                  src={empty}
+                  alt="empty"
+                  width={16}
+                  height={16}
+                  className={`md:w-5 md:h-5`}
+                />
+              )}
+            </div>
+          </div>
+          <div className="flex items-center gap-[22px]">
+            <p className="text-subtext2 hidden md:flex text-mobile_body3_r">
+              {format(new Date(notice.createdDateTime), "yyyy.MM.dd")}
+            </p>
+            <div className="flex gap-1 md:gap-[6px]">
+              <Image
+                src={vector}
+                alt="vector"
+                width={24}
+                height={24}
+                className={`cursor-pointer transition-transform duration-300 ${
+                  isOpen ? "rotate-180" : ""
+                }`}
+                onClick={handleVectorClick}
+              />
+            </div>
+          </div>
+        </div>
+        <p className="text-subtext2 text-mobile_body4_r md:hidden">
+          {format(new Date(notice.createdDateTime), "yyyy.MM.dd")}
+        </p>
+      </div>
+
+      {isOpen && (
+        <div className="md:mt-[34px] mt-4">
+          <div className="flex items-center gap-10">
+            <Image
+              src={noti}
+              alt="noti"
+              width={32}
+              height={32}
+              className="ml-[17px] md:block hidden self-start"
+            />
+            <div className="flex w-full flex-col gap-[14px] md:gap-[23px]">
+              <h1 className="text-subtext1 text-mobile_body1_r md:text-body1_r">
+                {notice.body}
+              </h1>
+              <div className="flex justify-between items-center">
+                <p className="text-unselected text-mobile_body2_m md:text-body2_m">
+                  {notice.userName || "운영자"}
+                </p>
+              </div>
+            </div>
+          </div>
+
+          {notice.imageUrls && notice.imageUrls.length > 0 && (
+            <div {...handlers} className="relative w-full mt-4 md:mt-5">
+              <div className="relative w-full" style={{ paddingTop: "56.25%" }}>
+                <Image
+                  src={notice.imageUrls[currentImageIndex]}
+                  alt={`notice-image-${currentImageIndex + 1}`}
+                  layout="fill"
+                  objectFit="cover"
+                  className="absolute top-0 left-0 w-full h-full rounded-lg"
+                />
+              </div>
+              <div className="hidden md:block">
+                <RoundVectorBtn
+                  className={`absolute rotate-180 top-[calc(50%-24px)] ml-4 ${
+                    isFirstSlide ? "hidden" : "block"
+                  }`}
+                  imageSize={30}
+                  onClick={handleSliderPrevClick}
+                />
+                <RoundVectorBtn
+                  className={`absolute top-[calc(50%-24px)] right-4 ${
+                    isLastSlide ? "hidden" : "block"
+                  }`}
+                  imageSize={30}
+                  onClick={handleSliderNextClick}
+                />
+              </div>
+              <div className="absolute bottom-2 left-1/2 transform -translate-x-1/2 bg-white70 py-1 px-2.5 rounded-12 backdrop-blur-sm">
+                <p className="text-center text-mobile_body3_r md:text-body3_r text-subtext2">
+                  {currentImageIndex + 1} / {notice.imageUrls.length}
+                </p>
+              </div>
+            </div>
+          )}
+        </div>
+      )}
+
+      {alertMessage && (
+        <Alert text={alertMessage} onClose={() => setAlertMessage(null)} />
+      )}
+    </div>
+  );
+};
+
+export default NoticeDropdown;

--- a/app/(help)/help/page.tsx
+++ b/app/(help)/help/page.tsx
@@ -1,32 +1,117 @@
 "use client";
 
-import { Suspense, useState } from "react";
-import QuestionDropdown from "@/(club)/club/help/components/questionDropdown";
+import { Suspense, useEffect, useState } from "react";
 import ClubNoticeHeader from "@/(club)/club/management/activity/notice/components/clubNoticeHeader";
-import { FAQ_DATA } from "@/data/faq";
-import { NOTICE_DATA } from "@/data/clubNotice";
-import ClubNoticeDropdown from "@/components/dropdown/clubNoticeDropdown";
 import PlusBtn from "@/components/button/withIconBtn/plusBtn";
 import MobileHeaderSection from "./components/mobileHeaderSection";
+import FaqDropdown from "./components/faqDropdown";
+import { NOTICE_DETAIL, NOTICE_LIST, FAQ_DATA } from "@/data/service";
+import {
+  SystemNoticeType,
+  SystemNoticeDetailType,
+  SystemFaqData,
+} from "@/types/service";
+import {
+  getServiceNotices,
+  getServiceNoticesDetail,
+  getServiceFaqDetail,
+} from "@/api/service/api";
+import NoticeDropdown from "./components/noticeDropdown";
 
 const HelpPage = () => {
-  const [selectedFaq, setSelectedFaq] = useState<string | null>(null);
-  const [openDropdownId, setOpenDropdownId] = useState<string | null>(null);
+  const [selectedFaq, setSelectedFaq] = useState<number | null>(null);
+  const [faqList, setFaqList] = useState<SystemFaqData[]>([]);
+  const [openDropdownId, setOpenDropdownId] = useState<number | null>(null);
+  const [noticeList, setNoticeList] = useState<SystemNoticeType[]>([]);
+  const [noticeDetails, setNoticeDetails] = useState<
+    Record<number, SystemNoticeDetailType>
+  >({});
+  const [visibleNoticeCount, setVisibleNoticeCount] = useState<number>(10);
+  const [visibleFaqCount, setVisibleFaqCount] = useState<number>(10);
+
+  // 공지사항 리스트 API
+  useEffect(() => {
+    const fetchNotices = async () => {
+      try {
+        const res = await getServiceNotices();
+        setNoticeList(res);
+      } catch (err) {
+        console.error("공지사항 리스트 불러오기 실패:", err);
+      }
+    };
+    fetchNotices();
+  }, []);
+
+  // 공지사항 리스트 테스트용
+  // useEffect(() => {
+  //   setNoticeList(NOTICE_LIST);
+  // }, []);
+
+  // FAQ API
+  useEffect(() => {
+    const fetchFaqs = async () => {
+      try {
+        const res = await getServiceFaqDetail();
+        setFaqList(res);
+      } catch (err) {
+        console.error("FAQ 불러오기 실패:", err);
+      }
+    };
+    fetchFaqs();
+  }, []);
+
+  // FAQ 테스트용
+  // useEffect(() => {
+  //   setFaqList(FAQ_DATA);
+  // }, []);
+
+  const handleDropdownToggle = async (id: number) => {
+    const isOpen = openDropdownId === id;
+
+    if (isOpen) {
+      setOpenDropdownId(null);
+    } else {
+      setOpenDropdownId(id);
+
+      // 테스트용
+      // if (!noticeDetails[id]) {
+      //   setNoticeDetails((prev) => ({
+      //     ...prev,
+      //     [id]: NOTICE_DETAIL[id],
+      //   }));
+      // }
+
+      // 동아리 상세 API
+      if (!noticeDetails[id]) {
+        try {
+          const res = await getServiceNoticesDetail(id);
+          setNoticeDetails((prev) => ({
+            ...prev,
+            [id]: res,
+          }));
+        } catch (err) {
+          console.error("공지 상세 불러오기 실패:", err);
+        }
+      }
+    }
+  };
+
+  const handleLoadMoreNotices = () => {
+    setVisibleNoticeCount((prev) => prev + 10);
+  };
+
+  const handleLoadMoreFaqs = () => {
+    setVisibleFaqCount((prev) => prev + 10);
+  };
 
   return (
     <div className="mt-8 mb-20 md:mb-[124px]">
       <MobileHeaderSection />
       <div>
-        <h1
-          className="text-text1 text-mobile_h1_contents_title md:text-h1_contents_title 
-        md:mb-[22px] mb-5"
-        >
+        <h1 className="text-text1 text-mobile_h1_contents_title md:text-h1_contents_title md:mb-[22px] mb-5">
           자주 묻는 질문
         </h1>
-        <div
-          className="hidden pl-6 pr-[114px] py-1.5 mb-2.5 justify-between bg-white70 
-        text-subtext2 rounded-[4px] text-body1_m md:flex"
-        >
+        <div className="hidden pl-6 pr-[114px] py-1.5 mb-2.5 justify-between bg-white70 text-subtext2 rounded-[4px] text-body1_m md:flex">
           <div className="flex gap-[42px]">
             <p className="px-[19px]">분류</p>
             <p>제목</p>
@@ -34,50 +119,53 @@ const HelpPage = () => {
         </div>
         <Suspense fallback={<div>Loading..</div>}>
           <div className="flex flex-col gap-2.5">
-            {FAQ_DATA.map((item, index) => (
-              <QuestionDropdown
-                key={item.id}
+            {faqList.slice(0, visibleFaqCount).map((item, i) => (
+              <FaqDropdown
+                key={`faq-${item.id}-${i}`}
                 data={item}
-                myRoleType={"GENERAL"}
-                isOpen={item.id === selectedFaq}
+                isOpen={selectedFaq === item.id}
                 setSelected={setSelectedFaq}
               />
             ))}
           </div>
         </Suspense>
-        <div className="flex justify-center  mt-9 md:mt-10">
-          <PlusBtn title={"더보기"} onClick={() => {}} />
-        </div>
+
+        {faqList.length > visibleFaqCount && (
+          <div className="flex justify-center mt-9 md:mt-10">
+            <PlusBtn title={"더보기"} onClick={handleLoadMoreFaqs} />
+          </div>
+        )}
       </div>
       <div>
-        <h1
-          className="text-text1 text-mobile_h1_contents_title md:text-h1_contents_title md:mt-10
-          mt-12 md:mb-[22px] mb-5"
-        >
+        <h1 className="text-text1 text-mobile_h1_contents_title md:text-h1_contents_title md:mt-10 mt-12 md:mb-[22px] mb-5">
           서비스 공지사항
         </h1>
-        <p
-          className="text-subtext2 text-mobile_body2_m md:text-h4
-          mt-4 mb-5 md:mt-[22px] md:mb-[22px]"
-        >
-          총 {NOTICE_DATA.length}개의 공지사항이 있어요.
+        <p className="text-subtext2 text-mobile_body2_m md:text-h4 mt-4 mb-5 md:mt-[22px] md:mb-[22px]">
+          총 {noticeList.length}개의 공지사항이 있어요.
         </p>
         <ClubNoticeHeader role="SERVICE_ADMIN" />
         <div className="flex flex-col gap-2.5">
-          {NOTICE_DATA.map((notice) => (
-            <ClubNoticeDropdown
-              key={notice.id}
-              notice={notice}
-              isOpen={openDropdownId === notice.id}
-              setOpenDropdownId={setOpenDropdownId}
-              pin={false}
-              role="SERVICE_ADMIN"
-            />
-          ))}
+          {noticeList.slice(0, visibleNoticeCount).map((notice) => {
+            const isOpen = openDropdownId === notice.id;
+            const detailed = noticeDetails[notice.id];
+
+            return (
+              <NoticeDropdown
+                key={notice.id}
+                notice={{ ...notice, ...detailed }}
+                isOpen={isOpen}
+                setOpenDropdownId={() => handleDropdownToggle(notice.id)}
+                pin={false}
+              />
+            );
+          })}
         </div>
-        <div className="flex justify-center  mt-9 md:mt-10">
-          <PlusBtn title={"더보기"} onClick={() => {}} />
-        </div>
+
+        {noticeList.length > visibleNoticeCount && (
+          <div className="flex justify-center mt-9 md:mt-10">
+            <PlusBtn title={"더보기"} onClick={handleLoadMoreNotices} />
+          </div>
+        )}
       </div>
     </div>
   );

--- a/app/(help)/help/page.tsx
+++ b/app/(help)/help/page.tsx
@@ -148,7 +148,7 @@ const HelpPage = () => {
         </p>
         <ClubNoticeHeader role="SERVICE_ADMIN" />
         <div className="flex flex-col gap-2.5">
-          {noticeList.slice(0, visibleNoticeCount).map((notice) => {
+          {noticeList.slice(0, visibleNoticeCount).map((notice, index) => {
             const isOpen = openDropdownId === notice.id;
             const detailed = noticeDetails[notice.id];
 
@@ -159,6 +159,7 @@ const HelpPage = () => {
                 isOpen={isOpen}
                 setOpenDropdownId={() => handleDropdownToggle(notice.id)}
                 pin={false}
+                index={index}
               />
             );
           })}

--- a/app/(help)/help/page.tsx
+++ b/app/(help)/help/page.tsx
@@ -17,8 +17,11 @@ import {
   getServiceFaqDetail,
 } from "@/api/service/api";
 import NoticeDropdown from "./components/noticeDropdown";
+import useResponsive from "@/hooks/useResponsive";
 
 const HelpPage = () => {
+  const isMd = useResponsive("md");
+
   const [selectedFaq, setSelectedFaq] = useState<number | null>(null);
   const [faqList, setFaqList] = useState<SystemFaqData[]>([]);
   const [openDropdownId, setOpenDropdownId] = useState<number | null>(null);
@@ -106,7 +109,7 @@ const HelpPage = () => {
 
   return (
     <div className="mt-8 mb-20 md:mb-[124px]">
-      <MobileHeaderSection />
+      {!isMd && <MobileHeaderSection />}
       <div>
         <h1 className="text-text1 text-mobile_h1_contents_title md:text-h1_contents_title md:mb-[22px] mb-5">
           자주 묻는 질문

--- a/app/api/apiUrl.ts
+++ b/app/api/apiUrl.ts
@@ -52,7 +52,6 @@ export const APPLY_TEMPS_MY = "/apply-temps/my";
 export const APPLY_FORM = "/apply-forms";
 
 // == REPORT ==
-
 export const REPORT_CLUB = "/report/clubs";
 export const REPORT_MEMBER = "/report/members";
 export const REPORT_PASSREVIEW = "/report/passReview";
@@ -63,8 +62,6 @@ export const REPORT_APPLY = "/report/apply";
 export const REPORT_RECRUITMENT = "/report/recruitments";
 export const REPORT_CLUB_REVIEW = "/report/clubReviews";
 
-// == CLUB_FINANCE ==
-export const FINANCIAL_RECORDS = "/financial-records";
-
-// == CLUB_REVIEW ==
-export const CLUB_REVIEW_TAG = "club-review/tag-data";
+// == SERVICE ==
+export const SERVICE_NOTICES = "/service-notices";
+export const SERVICE_FAQS = "/service-faqs";

--- a/app/api/apiUrl.ts
+++ b/app/api/apiUrl.ts
@@ -65,3 +65,9 @@ export const REPORT_CLUB_REVIEW = "/report/clubReviews";
 // == SERVICE ==
 export const SERVICE_NOTICES = "/service-notices";
 export const SERVICE_FAQS = "/service-faqs";
+
+// == CLUB_FINANCE ==
+export const FINANCIAL_RECORDS = "/financial-records";
+
+// == CLUB_REVIEW ==
+export const CLUB_REVIEW_TAG = "club-review/tag-data";

--- a/app/api/service/api.ts
+++ b/app/api/service/api.ts
@@ -15,7 +15,7 @@ export const getServiceNotices = async () => {
 // 서비스 공지사항 상세 조회
 export const getServiceNoticesDetail = async (systemNoticeId: number) => {
   const { data } = await axios.get<SystemNoticeDetailResponse>(
-    `${SERVICE_NOTICES}/${systemNoticeId}`
+    `${SERVICE_NOTICES}/${systemNoticeId}/details`
   );
   return data.systemNoticeData;
 };

--- a/app/api/service/api.ts
+++ b/app/api/service/api.ts
@@ -1,0 +1,27 @@
+import {
+  SystemFaqDataResponse,
+  SystemNoticeDetailResponse,
+  SystemNoticeListResponse,
+} from "@/types/service";
+import axios from "axios";
+import { SERVICE_FAQS, SERVICE_NOTICES } from "../apiUrl";
+
+// 서비스 공지사항 리스트 조회
+export const getServiceNotices = async () => {
+  const { data } = await axios.get<SystemNoticeListResponse>(SERVICE_NOTICES);
+  return data.systemNoticeDataList;
+};
+
+// 서비스 공지사항 상세 조회
+export const getServiceNoticesDetail = async (systemNoticeId: number) => {
+  const { data } = await axios.get<SystemNoticeDetailResponse>(
+    `${SERVICE_NOTICES}/${systemNoticeId}`
+  );
+  return data.systemNoticeData;
+};
+
+// 서비스 FAQ 조회
+export const getServiceFaqDetail = async () => {
+  const { data } = await axios.get<SystemFaqDataResponse>(SERVICE_FAQS);
+  return data.systemFaqDataList;
+};

--- a/app/components/layout/footer.tsx
+++ b/app/components/layout/footer.tsx
@@ -11,10 +11,9 @@ const Footer = () => {
   const pathname = usePathname();
 
   const LINKS = [
-    { text: "개인정보처리방침", href: "/terms/privacy" },
-    { text: "회원약관", href: "/terms/user" },
-    { text: "동아리 운영원칙", href: "/terms/club" },
-    { text: "고객센터", href: "/support" },
+    { text: "개인정보처리방침", href: "/privacyPolicy" },
+    { text: "회원약관", href: "/terms" },
+    { text: "고객센터", href: "/help" },
   ];
 
   return (

--- a/app/components/layout/layout.tsx
+++ b/app/components/layout/layout.tsx
@@ -45,9 +45,10 @@ const Layout = ({ children }: { children: ReactNode }) => {
       <div className="flex flex-col min-h-screen">
         <Header />
         <main
-          className={`flex-grow flex justify-center items-center 
-            ${isBgComponent && "bg-sub_bg"} 
-            ${isBgComponentOnlyMobile && "md:bg-sub_bg"}`}
+          className={`flex-grow flex 
+    ${pathname.includes("/help") ? "" : "justify-center items-center"} 
+    ${isBgComponent && "bg-sub_bg"} 
+    ${isBgComponentOnlyMobile && "md:bg-sub_bg"}`}
         >
           <div
             className={`w-full ${

--- a/app/components/layout/layout.tsx
+++ b/app/components/layout/layout.tsx
@@ -45,8 +45,8 @@ const Layout = ({ children }: { children: ReactNode }) => {
       <div className="flex flex-col min-h-screen">
         <Header />
         <main
-          className={`flex-grow flex 
-    ${pathname.includes("/help") ? "" : "justify-center items-center"} 
+          className={`flex-grow flex justify-center 
+    ${pathname.includes("/help") ? "" : "items-center"} 
     ${isBgComponent && "bg-sub_bg"} 
     ${isBgComponentOnlyMobile && "md:bg-sub_bg"}`}
         >

--- a/app/data/service.ts
+++ b/app/data/service.ts
@@ -9,13 +9,13 @@ export const FAQ_DATA: SystemFaqData[] = [
     id: 673012345142939000,
     title: "아리아리에서 개발한 서비스의 배포 시작 방법",
     body: "main 브렌치에 push!",
-    systemFaqStatusType: "APPROVE",
+    systemFaqStatusType: "SECURITY",
   },
   {
     id: 553012345142939011,
     title: "동아리 멤버 관리 방법",
     body: "관리자 페이지에서 멤버 초대 및 권한 설정이 가능합니다.",
-    systemFaqStatusType: "APPROVE",
+    systemFaqStatusType: "SECURITY",
   },
 ];
 

--- a/app/data/service.ts
+++ b/app/data/service.ts
@@ -1,0 +1,52 @@
+import {
+  SystemFaqData,
+  SystemNoticeDetailType,
+  SystemNoticeType,
+} from "@/types/service";
+
+export const FAQ_DATA: SystemFaqData[] = [
+  {
+    id: 673012345142939000,
+    title: "아리아리에서 개발한 서비스의 배포 시작 방법",
+    body: "main 브렌치에 push!",
+    systemFaqStatusType: "APPROVE",
+  },
+  {
+    id: 553012345142939011,
+    title: "동아리 멤버 관리 방법",
+    body: "관리자 페이지에서 멤버 초대 및 권한 설정이 가능합니다.",
+    systemFaqStatusType: "APPROVE",
+  },
+];
+
+export const NOTICE_LIST: SystemNoticeType[] = [
+  {
+    id: 1,
+    title: "서비스 점검 안내",
+    body: "2025년 5월 1일 00:00 ~ 06:00까지 서버 점검이 예정되어 있습니다.",
+    createdDateTime: "2025-04-01T10:00:00.000Z",
+  },
+  {
+    id: 2,
+    title: "신규 기능 출시",
+    body: "새로운 채팅 기능이 추가되었습니다!",
+    createdDateTime: "2025-04-05T14:30:00.000Z",
+  },
+];
+
+export const NOTICE_DETAIL: Record<number, SystemNoticeDetailType> = {
+  1: {
+    id: 1,
+    title: "서비스 점검 안내",
+    body: "점검 중에는 서비스 이용이 불가합니다. 양해 부탁드립니다.",
+    imageUrls: [],
+    createdDateTime: "2025-04-01T10:00:00.000Z",
+  },
+  2: {
+    id: 2,
+    title: "신규 기능 출시",
+    body: "채팅 기능을 통해 사용자 간 실시간 소통이 가능해졌습니다!",
+    imageUrls: [],
+    createdDateTime: "2025-04-05T14:30:00.000Z",
+  },
+};

--- a/app/types/service.ts
+++ b/app/types/service.ts
@@ -1,0 +1,33 @@
+export interface SystemFaqData {
+  id: number;
+  title: string;
+  body: string;
+  systemFaqStatusType: "APPROVE" | "PENDING" | "REJECT";
+}
+
+export interface SystemNoticeType {
+  id: number;
+  title: string;
+  body: string;
+  createdDateTime: string;
+}
+
+export interface SystemNoticeDetailType {
+  id: number;
+  title: string;
+  body: string;
+  imageUrls?: string[];
+  createdDateTime: string;
+}
+
+export interface SystemFaqDataResponse {
+  systemFaqDataList: SystemFaqData[];
+}
+
+export interface SystemNoticeListResponse {
+  systemNoticeDataList: SystemNoticeType[];
+}
+
+export interface SystemNoticeDetailResponse {
+  systemNoticeData: SystemNoticeDetailType;
+}

--- a/app/types/service.ts
+++ b/app/types/service.ts
@@ -2,7 +2,7 @@ export interface SystemFaqData {
   id: number;
   title: string;
   body: string;
-  systemFaqStatusType: "APPROVE" | "PENDING" | "REJECT";
+  systemFaqStatusType: "SECURITY" | "APPROVE";
 }
 
 export interface SystemNoticeType {


### PR DESCRIPTION
## ✅ 주요 작업 사항
> Customer service center Page 컴포넌트 작업 및 API 연동

### 컴포넌트
- `NoticeDropdown` & `FaqDropdown` 생성

<br/>

## 🧪 테스트 화면
> `/help`
`테스트용` 코드 주석 해제 및 API 관련 코드 주석처리하면 임시 데이터로 확인 가능합니다.

<img src="https://github.com/user-attachments/assets/2eefa81d-10ec-4351-abba-5e72f0a02677" width="400" />
<img src="https://github.com/user-attachments/assets/82cee154-243a-4336-b1de-045bf7315f50" width="400" />

<img src="https://github.com/user-attachments/assets/618796f8-4812-45dc-b6bc-eddbfdd8325a" width="250" />
<img src="https://github.com/user-attachments/assets/abfe348b-74c0-4d63-8009-0ec664728e78" width="250" />

<br/>


## 📌 참고
- 현재 공지사항 API에 이미지 관련 `response`가 없는 상태입니다. 백엔드 요청 예정입니다.
- 공지사항 및 FAQ `등록/삭제`는 백오피스 기능으로, ariari에는 적용되지 않았습니다.
