### PR TITLE
[Feat] Application Status API

### DIFF
--- a/app/(club)/club/management/recruitment/applicationStatus/page.tsx
+++ b/app/(club)/club/management/recruitment/applicationStatus/page.tsx
@@ -19,8 +19,8 @@ import LeftMenu from "@/(club)/club/components/menu/leftMenu";
 import MobileMenu from "@/(club)/club/components/menu/mobileMenu";
 import { useApplicationQuery } from "@/hooks/apply/useApplicationQuery";
 import { useSearchParams } from "next/navigation";
-import { APPLY_STATUS } from "@/constants/application";
 import { formatLocalDateTime } from "@/utils/dateFormatter";
+import { ApplyData } from "@/types/application";
 
 // 상단 필터링 탭
 const FILTER_TABS = [
@@ -30,7 +30,7 @@ const FILTER_TABS = [
 const MOBILE_FILTER_TABS = [{ id: 0, label: "지원 상태" }, ...FILTER_TABS];
 
 // 지원현황 - 지원서별 지원 상태 변경
-const OPTIONS = [
+export const STATUS_OPTIONS = [
   { id: 1, label: "대기중" },
   { id: 2, label: "면접중" },
   { id: 3, label: "합격" },
@@ -238,7 +238,7 @@ const ApplicationStatusPage = () => {
                       >
                         <SingleSelectOptions
                           selectedOption={""}
-                          optionData={OPTIONS}
+                          optionData={STATUS_OPTIONS}
                           size="medium"
                           handleMenuClick={handleMenuClick}
                         />
@@ -270,15 +270,13 @@ const ApplicationStatusPage = () => {
                   </div>
                 </div>
               )}
+              {/* 지원서 목록 */}
               <div className="flex flex-col  gap-2.5">
-                {applicationsList.map((item) => {
+                {applicationsList.map((item: ApplyData) => {
                   return (
                     <ApplicationFormCard
                       key={item.id}
-                      clubName={item.name}
-                      serviceNickname={item.memberData.nickname}
-                      status={APPLY_STATUS[item.applyStatusType]}
-                      recruitmentTitle={item.recruitmentTitle}
+                      applyInfo={item}
                       isChecked={checkedApplications.includes(item.id)}
                       onClick={handleOpenForm}
                       onCheck={(isChecked) =>
@@ -299,7 +297,7 @@ const ApplicationStatusPage = () => {
         {isMdUp ? isFormOpen && null : isFormOpen && null}
         {isOptionsOpen && !isMdUp && (
           <CommonBottomSheet
-            optionData={OPTIONS}
+            optionData={STATUS_OPTIONS}
             selectedOption={""}
             handleMenuClick={handleMenuClick}
             onClose={() => setIsOptionsOpen(false)}

--- a/app/(club)/club/management/recruitment/applicationStatus/page.tsx
+++ b/app/(club)/club/management/recruitment/applicationStatus/page.tsx
@@ -21,6 +21,7 @@ import { useApplicationQuery } from "@/hooks/apply/useApplicationQuery";
 import { useSearchParams } from "next/navigation";
 import { formatLocalDateTime } from "@/utils/dateFormatter";
 import { ApplyData } from "@/types/application";
+import { APPLY_STATUS } from "@/constants/application";
 
 // 상단 필터링 탭
 const FILTER_TABS = [
@@ -279,7 +280,7 @@ const ApplicationStatusPage = () => {
                       isChecked={checkedApplications.includes(item.id)}
                       onClick={handleOpenForm}
                       onCheck={(isChecked) =>
-                        handleSingleCheck(item.id, isChecked)
+                        handleSingleCheck(Number(item.id), isChecked)
                       }
                     />
                   );

--- a/app/(club)/club/management/recruitment/applicationStatus/page.tsx
+++ b/app/(club)/club/management/recruitment/applicationStatus/page.tsx
@@ -20,12 +20,12 @@ import { ApplyData } from "@/types/application";
 import { useUpdateStatusMutation } from "@/hooks/apply/useApplicationMutation";
 import { APPLY_STATUS_VALUE_MAP } from "@/constants/application";
 import Alert from "@/components/alert/alert";
-import UpdateApplyStatusOptions from "@/components/dropdown/updateApplyStatusOptions";
 import { useApplyStatusOptions } from "@/hooks/apply/useApplyStatusOptions";
 import InterviewNoticeModal from "@/components/modal/club/interviewNoticeModal";
 import InterviewNoticeBottomSheet from "@/components/bottomSheet/interviewNoticeBottomSheet";
 import ApplicationFromViewModal from "@/components/modal/club/applicationFormViewModal";
 import MobileApplicationFormViewModal from "@/components/modal/club/mobileApplicationFormViewModal";
+import UpdateApplyStatusOptions from "@/components/dropdown/updateApplyStatusOptions";
 
 // 상단 필터링 탭
 const FILTER_TABS = [
@@ -66,14 +66,12 @@ const ApplicationStatusPage = () => {
   const {
     isModalOpen,
     setIsModalOpen,
-    isOptionsOpen,
-    setIsOptionsOpen,
+    // isOptionsOpen,
+    // setIsOptionsOpen,
     selectedOption,
     setSelectedOption,
     isInterviewOpen,
     setIsInterviewOpen,
-
-    optionsRef,
   } = useApplyStatusOptions();
 
   // 지원 목록 조건에 따른 필터링
@@ -136,13 +134,13 @@ const ApplicationStatusPage = () => {
   };
 
   // 지원 상태 변경 옵션 목록 중 메뉴 클릭
-  const handleMenuClick = (label: string) => {
-    setIsOptionsOpen(false);
-    if (!checkedApplications.length) {
-      setAlertMessage("선택된 지원서가 없습니다.");
-      return;
-    }
-  };
+  // const handleMenuClick = (label: string) => {
+  //   setIsOptionsOpen(false);
+  //   if (!checkedApplications.length) {
+  //     setAlertMessage("선택된 지원서가 없습니다.");
+  //     return;
+  //   }
+  // };
 
   // 지원 상태 변경 확인 모달 내 '변경하기' 버튼 클릭
   const handleStatusChange = () => {
@@ -268,12 +266,9 @@ const ApplicationStatusPage = () => {
                   />
                   <UpdateApplyStatusOptions
                     checkedApplications={checkedApplications}
-                    isOptionsOpen={isOptionsOpen}
-                    setIsOptionsOpen={setIsOptionsOpen}
                     setSelectedStatus={setSelectedOption}
                     setAlertMessage={setAlertMessage}
                     setIsModalOpen={setIsModalOpen}
-                    optionsRef={optionsRef}
                   />
                 </div>
               ) : (
@@ -291,12 +286,9 @@ const ApplicationStatusPage = () => {
                   />
                   <UpdateApplyStatusOptions
                     checkedApplications={checkedApplications}
-                    isOptionsOpen={isOptionsOpen}
-                    setIsOptionsOpen={setIsOptionsOpen}
                     setSelectedStatus={setSelectedOption}
                     setAlertMessage={setAlertMessage}
                     setIsModalOpen={setIsModalOpen}
-                    optionsRef={optionsRef}
                   />
                 </div>
               )}
@@ -342,6 +334,25 @@ const ApplicationStatusPage = () => {
         />
       )}
 
+      {/* ===== 지원서 상세보기 모달 =====*/}
+      {isMdUp
+        ? openApplicationId && (
+            <ApplicationFromViewModal
+              applyId={openApplicationId}
+              onClose={() => setOpenApplicationId(null)}
+              setIsModalOpen={setIsModalOpen}
+              setSelectedOption={setSelectedOption}
+            />
+          )
+        : openApplicationId && (
+            <MobileApplicationFormViewModal
+              applyId={openApplicationId}
+              onClose={() => setOpenApplicationId(null)}
+              setIsModalOpen={setIsModalOpen}
+              setSelectedOption={setSelectedOption}
+            />
+          )}
+
       {/* ===== 면접 확인 메세지 전송 모달 ===== */}
       {isMdUp
         ? isInterviewOpen && (
@@ -358,29 +369,6 @@ const ApplicationStatusPage = () => {
               onSubmit={(message: string) =>
                 handleSubmitInterviewNotice(message)
               }
-            />
-          )}
-
-      {/* ===== 지원서 상세보기 모달 =====*/}
-      {isMdUp
-        ? openApplicationId && (
-            <ApplicationFromViewModal
-              applyId={openApplicationId}
-              onClose={() => setOpenApplicationId(null)}
-              setIsModalOpen={setIsModalOpen}
-              setSelectedOption={setSelectedOption}
-              isOptionsOpen={isOptionsOpen}
-              setIsOptionsOpen={setIsOptionsOpen}
-            />
-          )
-        : openApplicationId && (
-            <MobileApplicationFormViewModal
-              applyId={openApplicationId}
-              setIsOptionsOpen={setIsOptionsOpen}
-              onClose={() => setOpenApplicationId(null)}
-              setIsModalOpen={setIsModalOpen}
-              setSelectedOption={setSelectedOption}
-              isOptionsOpen={isOptionsOpen}
             />
           )}
 

--- a/app/(club)/club/management/recruitment/applicationStatus/page.tsx
+++ b/app/(club)/club/management/recruitment/applicationStatus/page.tsx
@@ -31,10 +31,9 @@ const MOBILE_FILTER_TABS = [{ id: 0, label: "지원 상태" }, ...FILTER_TABS];
 
 // 지원현황 - 지원서별 지원 상태 변경
 export const STATUS_OPTIONS = [
-  { id: 1, label: "대기중" },
-  { id: 2, label: "면접중" },
-  { id: 3, label: "합격" },
-  { id: 4, label: "불합격" },
+  { id: 1, label: "면접중" },
+  { id: 2, label: "합격" },
+  { id: 3, label: "불합격" },
 ];
 
 const ApplicationStatusPage = () => {

--- a/app/(club)/club/management/recruitment/applicationStatus/page.tsx
+++ b/app/(club)/club/management/recruitment/applicationStatus/page.tsx
@@ -21,7 +21,9 @@ import { useApplicationQuery } from "@/hooks/apply/useApplicationQuery";
 import { useSearchParams } from "next/navigation";
 import { formatLocalDateTime } from "@/utils/dateFormatter";
 import { ApplyData } from "@/types/application";
-import { APPLY_STATUS } from "@/constants/application";
+import { useUpdateStatusMutation } from "@/hooks/apply/useApplicationMutation";
+import { APPLY_STATUS_VALUE_MAP } from "@/constants/application";
+import Alert from "@/components/alert/alert";
 
 // 상단 필터링 탭
 const FILTER_TABS = [
@@ -30,7 +32,7 @@ const FILTER_TABS = [
 ];
 const MOBILE_FILTER_TABS = [{ id: 0, label: "지원 상태" }, ...FILTER_TABS];
 
-// 지원현황 - 지원서별 지원 상태 변경
+// 지원현황 - 지원서별 지원 상태 변경 옵션
 export const STATUS_OPTIONS = [
   { id: 1, label: "면접중" },
   { id: 2, label: "합격" },
@@ -51,6 +53,7 @@ const ApplicationStatusPage = () => {
   const [isOptionsOpen, setIsOptionsOpen] = useState<boolean>(false); // 지원상태 변경 옵션 목록 open 여부
   const [selectedStatus, setSelectedStatus] = useState<string>(""); // 변경하고자 하는 지원 상태
   const [isModalOpen, setIsModalOpen] = useState<boolean>(false); // 지원상태 변경 확인 모달 open 여부
+  const [alertMessage, setAlertMessage] = useState<string | null>(null);
 
   const [searchQuery, setSearchQuery] = useState<string>("");
   const [dateRange, setDateRange] = useState<[Date | null, Date | null]>([
@@ -61,6 +64,7 @@ const ApplicationStatusPage = () => {
   const [isFormOpen, setIsFormOpen] = useState<boolean>(false); // 지원서 상세 열람 모달 open 여부
   const [checkedApplications, setCheckedApplications] = useState<string[]>([]);
 
+  // 지원 목록 조건에 따른 필터링
   const {
     allTabSize,
     pendingTabSize,
@@ -77,7 +81,25 @@ const ApplicationStatusPage = () => {
     endDateTime: dateRange[1] ? formatLocalDateTime(dateRange[1]) : undefined,
   });
 
+  // 지원 상태 변경 mutation 훅
+  const { updateApplicationStatus } = useUpdateStatusMutation({
+    options: {
+      onSuccess: () => {
+        setAlertMessage("지원 상태를 성공적으로 변경했습니다.");
+        setCheckedApplications([]);
+      },
+      onError: () => {
+        setAlertMessage("지원 상태를 변경할 수 없습니다.");
+      },
+    },
+  });
+
+  // 지원 상태 변경 옵션 목록 중 메뉴 클릭
   const handleMenuClick = (label: string) => {
+    if (!checkedApplications.length) {
+      setAlertMessage("선택된 지원서가 없습니다.");
+      return;
+    }
     setSelectedStatus(label);
     setIsOptionsOpen(false);
     setIsModalOpen(true);
@@ -109,7 +131,12 @@ const ApplicationStatusPage = () => {
     }
   };
 
+  // 지원 상태 변경 확인 모달 내 '변경하기' 버튼 클릭
   const handleStatusChange = () => {
+    updateApplicationStatus.mutate({
+      applications: checkedApplications,
+      type: APPLY_STATUS_VALUE_MAP[selectedStatus],
+    });
     setIsModalOpen(false);
   };
 
@@ -318,6 +345,10 @@ const ApplicationStatusPage = () => {
           />
         )}
       </div>
+      {/* ====== 알림 ======*/}
+      {alertMessage && (
+        <Alert text={alertMessage} onClose={() => setAlertMessage(null)} />
+      )}
     </>
   );
 };

--- a/app/(club)/club/management/recruitment/applicationStatus/page.tsx
+++ b/app/(club)/club/management/recruitment/applicationStatus/page.tsx
@@ -105,16 +105,13 @@ const ApplicationStatusPage = () => {
     setIsModalOpen(true);
   };
 
-  const handleReset = () => {
-    setDateRange([null, null]);
-    setSearchQuery("");
-    setCheckedApplications([]);
-  };
-
+  // 검색 input query 변경
+  // 기준: 1. 서비스 이름, 2. 지원서 이름, 3. 모집 공고 제목
   const handleSearchQuery = (query: string) => {
     setSearchQuery(query);
   };
 
+  // 지원서 선택(checkbox)
   const handleAllCheck = (isChecked: boolean) => {
     if (isChecked) {
       setCheckedApplications(applicationsList.map((item) => item.id));
@@ -122,13 +119,19 @@ const ApplicationStatusPage = () => {
       setCheckedApplications([]);
     }
   };
-
   const handleSingleCheck = (id: string, isChecked: boolean) => {
     if (isChecked) {
       setCheckedApplications((prev) => [...prev, id]);
     } else {
       setCheckedApplications((prev) => prev.filter((item) => item !== id));
     }
+  };
+
+  // 필터링 조건 초기화
+  const handleReset = () => {
+    setDateRange([null, null]);
+    setSearchQuery("");
+    setCheckedApplications([]);
   };
 
   // 지원 상태 변경 확인 모달 내 '변경하기' 버튼 클릭
@@ -138,10 +141,6 @@ const ApplicationStatusPage = () => {
       type: APPLY_STATUS_VALUE_MAP[selectedStatus],
     });
     setIsModalOpen(false);
-  };
-
-  const handleOpenForm = () => {
-    setIsFormOpen(true);
   };
 
   useEffect(() => {

--- a/app/(club)/club/management/recruitment/applicationStatus/page.tsx
+++ b/app/(club)/club/management/recruitment/applicationStatus/page.tsx
@@ -10,7 +10,6 @@ import AllCheckBox from "@/components/checkBox/allCheckBox";
 import ApplicationFormCard from "@/components/card/applicationFormCard";
 import vector from "@/images/icon/sub_pull_down.svg";
 import SingleSelectOptions from "@/components/pulldown/singleSelectOptions";
-import { APPLICATION_FORM_DATA } from "@/data/application";
 import NotiPopUp from "@/components/modal/notiPopUp";
 import PullDown from "@/components/pulldown/pullDown";
 import SubSearchInput from "@/components/input/subSearchInput";
@@ -60,7 +59,7 @@ const ApplicationStatusPage = () => {
   ]);
 
   const [isFormOpen, setIsFormOpen] = useState<boolean>(false); // 지원서 상세 열람 모달 open 여부
-  const [checkedApplications, setCheckedApplications] = useState<number[]>([]);
+  const [checkedApplications, setCheckedApplications] = useState<string[]>([]);
 
   const {
     allTabSize,
@@ -84,19 +83,25 @@ const ApplicationStatusPage = () => {
     setIsModalOpen(true);
   };
 
+  const handleReset = () => {
+    setDateRange([null, null]);
+    setSearchQuery("");
+    setCheckedApplications([]);
+  };
+
   const handleSearchQuery = (query: string) => {
     setSearchQuery(query);
   };
 
   const handleAllCheck = (isChecked: boolean) => {
     if (isChecked) {
-      setCheckedApplications(APPLICATION_FORM_DATA.map((item) => item.id));
+      setCheckedApplications(applicationsList.map((item) => item.id));
     } else {
       setCheckedApplications([]);
     }
   };
 
-  const handleSingleCheck = (id: number, isChecked: boolean) => {
+  const handleSingleCheck = (id: string, isChecked: boolean) => {
     if (isChecked) {
       setCheckedApplications((prev) => [...prev, id]);
     } else {
@@ -163,7 +168,7 @@ const ApplicationStatusPage = () => {
                     type={"reset"}
                     size={"small"}
                     title={isMdUp ? "초기화" : ""}
-                    onClick={() => {}}
+                    onClick={handleReset}
                     className="whitespace-nowrap lg:mr-3.5"
                   />
                   <div className="lg:hidden flex items-center">
@@ -180,7 +185,10 @@ const ApplicationStatusPage = () => {
                     />
                   </div>
                   <div className="smm:block hidden">
-                    <RangeCalendar onDateChange={setDateRange} />
+                    <RangeCalendar
+                      onDateChange={setDateRange}
+                      selectedRange={dateRange}
+                    />
                   </div>
 
                   <SubSearchInput
@@ -190,7 +198,10 @@ const ApplicationStatusPage = () => {
                   />
                 </div>
                 <div className="smm:hidden block">
-                  <RangeCalendar onDateChange={setDateRange} />
+                  <RangeCalendar
+                    onDateChange={setDateRange}
+                    selectedRange={dateRange}
+                  />
                 </div>
                 <SubSearchInput
                   onSearch={handleSearchQuery}
@@ -205,14 +216,12 @@ const ApplicationStatusPage = () => {
                 >
                   <AllCheckBox
                     isChecked={
-                      checkedApplications.length ===
-                      APPLICATION_FORM_DATA.length
+                      checkedApplications.length === applicationsList.length
                     }
                     label={"전체 선택"}
                     onClick={() =>
                       handleAllCheck(
-                        checkedApplications.length !==
-                          APPLICATION_FORM_DATA.length
+                        checkedApplications.length !== applicationsList.length
                       )
                     }
                   />
@@ -241,14 +250,12 @@ const ApplicationStatusPage = () => {
                 <div className="flex justify-between mb-4">
                   <AllCheckBox
                     isChecked={
-                      checkedApplications.length ===
-                      APPLICATION_FORM_DATA.length
+                      checkedApplications.length === applicationsList.length
                     }
                     label={"전체 선택"}
                     onClick={() =>
                       handleAllCheck(
-                        checkedApplications.length !==
-                          APPLICATION_FORM_DATA.length
+                        checkedApplications.length !== applicationsList.length
                       )
                     }
                   />
@@ -272,10 +279,10 @@ const ApplicationStatusPage = () => {
                       serviceNickname={item.memberData.nickname}
                       status={APPLY_STATUS[item.applyStatusType]}
                       recruitmentTitle={item.recruitmentTitle}
-                      isChecked={checkedApplications.includes(Number(item.id))}
+                      isChecked={checkedApplications.includes(item.id)}
                       onClick={handleOpenForm}
                       onCheck={(isChecked) =>
-                        handleSingleCheck(Number(item.id), isChecked)
+                        handleSingleCheck(item.id, isChecked)
                       }
                     />
                   );

--- a/app/(club)/club/management/recruitment/applicationStatus/page.tsx
+++ b/app/(club)/club/management/recruitment/applicationStatus/page.tsx
@@ -280,7 +280,7 @@ const ApplicationStatusPage = () => {
                       isChecked={checkedApplications.includes(item.id)}
                       onClick={handleOpenForm}
                       onCheck={(isChecked) =>
-                        handleSingleCheck(Number(item.id), isChecked)
+                        handleSingleCheck(item.id, isChecked)
                       }
                     />
                   );

--- a/app/(club)/club/management/recruitment/applicationStatus/page.tsx
+++ b/app/(club)/club/management/recruitment/applicationStatus/page.tsx
@@ -1,20 +1,16 @@
 "use client";
 
-import React, { useEffect, useRef, useState } from "react";
-import Image from "next/image";
+import React, { useEffect, useState } from "react";
 import PlusBtn from "@/components/button/withIconBtn/plusBtn";
 import SubTap from "@/components/tab/subTap";
 import useResponsive from "@/hooks/useResponsive";
 import IconBtn from "@/components/button/withIconBtn/IconBtn";
 import AllCheckBox from "@/components/checkBox/allCheckBox";
 import ApplicationFormCard from "@/components/card/applicationFormCard";
-import vector from "@/images/icon/sub_pull_down.svg";
-import SingleSelectOptions from "@/components/pulldown/singleSelectOptions";
 import NotiPopUp from "@/components/modal/notiPopUp";
 import PullDown from "@/components/pulldown/pullDown";
 import SubSearchInput from "@/components/input/subSearchInput";
 import RangeCalendar from "@/components/calendar/rangeCalendar";
-import CommonBottomSheet from "@/components/bottomSheet/commonBottomSheet";
 import LeftMenu from "@/(club)/club/components/menu/leftMenu";
 import MobileMenu from "@/(club)/club/components/menu/mobileMenu";
 import { useApplicationQuery } from "@/hooks/apply/useApplicationQuery";
@@ -24,6 +20,7 @@ import { ApplyData } from "@/types/application";
 import { useUpdateStatusMutation } from "@/hooks/apply/useApplicationMutation";
 import { APPLY_STATUS_VALUE_MAP } from "@/constants/application";
 import Alert from "@/components/alert/alert";
+import UpdateApplyStatusOptions from "@/components/dropdown/UpdateApplyStatusOptions";
 
 // 상단 필터링 탭
 const FILTER_TABS = [
@@ -44,7 +41,6 @@ const ApplicationStatusPage = () => {
   const clubId = params.get("clubId") ?? "";
 
   const isMdUp = useResponsive("md");
-  const optionsRef = useRef<HTMLDivElement | null>(null);
 
   const [filters, setFilters] = useState(FILTER_TABS);
   const [selectedFilter, setSelectedFilter] = useState<string>(
@@ -94,17 +90,6 @@ const ApplicationStatusPage = () => {
     },
   });
 
-  // 지원 상태 변경 옵션 목록 중 메뉴 클릭
-  const handleMenuClick = (label: string) => {
-    if (!checkedApplications.length) {
-      setAlertMessage("선택된 지원서가 없습니다.");
-      return;
-    }
-    setSelectedStatus(label);
-    setIsOptionsOpen(false);
-    setIsModalOpen(true);
-  };
-
   // 검색 input query 변경
   // 기준: 1. 서비스 이름, 2. 지원서 이름, 3. 모집 공고 제목
   const handleSearchQuery = (query: string) => {
@@ -142,21 +127,6 @@ const ApplicationStatusPage = () => {
     });
     setIsModalOpen(false);
   };
-
-  useEffect(() => {
-    const handleClickOutside = (event: MouseEvent) => {
-      if (
-        optionsRef.current &&
-        !optionsRef.current.contains(event.target as Node)
-      ) {
-        setIsOptionsOpen(false);
-      }
-    };
-    document.addEventListener("mousedown", handleClickOutside);
-    return () => {
-      document.removeEventListener("mousedown", handleClickOutside);
-    };
-  }, []);
 
   useEffect(() => {
     setFilters((prev) => [
@@ -251,26 +221,14 @@ const ApplicationStatusPage = () => {
                       )
                     }
                   />
-                  <div
-                    className="relative flex items-center gap-2 cursor-pointer"
-                    onClick={() => setIsOptionsOpen(!isOptionsOpen)}
-                  >
-                    <p>지원상태 변경</p>
-                    <Image alt={"버튼"} src={vector} width={28} height={28} />
-                    {isOptionsOpen && (
-                      <div
-                        ref={optionsRef}
-                        className="absolute top-full mt-2 z-50 left-12"
-                      >
-                        <SingleSelectOptions
-                          selectedOption={""}
-                          optionData={STATUS_OPTIONS}
-                          size="medium"
-                          handleMenuClick={handleMenuClick}
-                        />
-                      </div>
-                    )}
-                  </div>
+                  <UpdateApplyStatusOptions
+                    checkedApplications={checkedApplications}
+                    isOptionsOpen={isOptionsOpen}
+                    setIsOptionsOpen={setIsOptionsOpen}
+                    setSelectedStatus={setSelectedStatus}
+                    setAlertMessage={setAlertMessage}
+                    setIsModalOpen={setIsModalOpen}
+                  />
                 </div>
               ) : (
                 <div className="flex justify-between mb-4">
@@ -285,15 +243,14 @@ const ApplicationStatusPage = () => {
                       )
                     }
                   />
-                  <div
-                    className="flex gap-1 items-center"
-                    onClick={() => setIsOptionsOpen(true)}
-                  >
-                    <p className="text-subtext2 text-mobile_body2_m">
-                      지원상태 변경
-                    </p>
-                    <Image alt={"버튼"} src={vector} width={20} height={20} />
-                  </div>
+                  <UpdateApplyStatusOptions
+                    checkedApplications={checkedApplications}
+                    isOptionsOpen={isOptionsOpen}
+                    setIsOptionsOpen={setIsOptionsOpen}
+                    setSelectedStatus={setSelectedStatus}
+                    setAlertMessage={setAlertMessage}
+                    setIsModalOpen={setIsModalOpen}
+                  />
                 </div>
               )}
               {/* 지원서 목록 */}
@@ -321,14 +278,6 @@ const ApplicationStatusPage = () => {
           </div>
         </div>
         {isMdUp ? isFormOpen && null : isFormOpen && null}
-        {isOptionsOpen && !isMdUp && (
-          <CommonBottomSheet
-            optionData={STATUS_OPTIONS}
-            selectedOption={""}
-            handleMenuClick={handleMenuClick}
-            onClose={() => setIsOptionsOpen(false)}
-          />
-        )}
 
         {isModalOpen && (
           <NotiPopUp

--- a/app/(club)/club/management/recruitment/applicationStatus/page.tsx
+++ b/app/(club)/club/management/recruitment/applicationStatus/page.tsx
@@ -19,39 +19,36 @@ import CommonBottomSheet from "@/components/bottomSheet/commonBottomSheet";
 import LeftMenu from "@/(club)/club/components/menu/leftMenu";
 import MobileMenu from "@/(club)/club/components/menu/mobileMenu";
 
-const OPTIONS = [
-  { id: 0, label: "전체", number: 14 },
-  { id: 1, label: "대기중", number: 14 },
-  { id: 2, label: "면접중", number: 14 },
-  { id: 3, label: "합격", number: 14 },
-  { id: 4, label: "불합격", number: 14 },
+// 상단 필터링 탭
+const FILTER_TABS = [
+  { id: 1, label: "전체" },
+  { id: 2, label: "대기중" },
 ];
+const MOBILE_FILTER_TABS = [{ id: 0, label: "지원 상태" }, ...FILTER_TABS];
 
-const MOBILE_OPTIONS = [
-  { id: 0, label: "지원 상태", number: 14 },
-  { id: 1, label: "대기중", number: 14 },
-  { id: 2, label: "면접중", number: 14 },
-  { id: 3, label: "합격", number: 14 },
-  { id: 4, label: "불합격", number: 14 },
+// 지원현황 - 지원서별 지원 상태 변경
+const OPTIONS = [
+  { id: 1, label: "대기중" },
+  { id: 2, label: "면접중" },
+  { id: 3, label: "합격" },
+  { id: 4, label: "불합격" },
 ];
 
 const ApplicationStatusPage = () => {
   const isMdUp = useResponsive("md");
   const optionsRef = useRef<HTMLDivElement | null>(null);
 
-  const [option, setOption] = useState<string>(OPTIONS[0].label);
-  const [isOptionsOpen, setIsOptionsOpen] = useState<boolean>(false);
-  const [isModalOpen, setIsModalOpen] = useState<boolean>(false);
-  const [openForm, setOpenForm] = useState<boolean>(false);
-  const [selectedOption, setSelectedOption] = useState<string>("");
-  const [selectedStatus, setSelectedStatus] = useState<string>("");
-  const [selectedSortOption, setSelectedSortOption] = useState<string[]>([]);
-  const [selectedApplications, setSelectedApplications] = useState<number[]>(
-    []
+  const [selectedFilter, setSelectedFilter] = useState<string>(
+    FILTER_TABS[0].label
   );
+  const [isOptionsOpen, setIsOptionsOpen] = useState<boolean>(false); // 지원상태 변경 옵션 목록 open 여부
+  const [selectedStatus, setSelectedStatus] = useState<string>(""); // 변경하고자 하는 지원 상태
+  const [isModalOpen, setIsModalOpen] = useState<boolean>(false); // 지원상태 변경 확인 모달 open 여부
+
+  const [isFormOpen, setIsFormOpen] = useState<boolean>(false); // 지원서 상세 열람 모달 open 여부
+  const [checkedApplications, setCheckedApplications] = useState<number[]>([]);
 
   const handleMenuClick = (label: string) => {
-    setSelectedOption("");
     setSelectedStatus(label);
     setIsOptionsOpen(false);
     setIsModalOpen(true);
@@ -59,17 +56,17 @@ const ApplicationStatusPage = () => {
 
   const handleAllCheck = (isChecked: boolean) => {
     if (isChecked) {
-      setSelectedApplications(APPLICATION_FORM_DATA.map((item) => item.id));
+      setCheckedApplications(APPLICATION_FORM_DATA.map((item) => item.id));
     } else {
-      setSelectedApplications([]);
+      setCheckedApplications([]);
     }
   };
 
   const handleSingleCheck = (id: number, isChecked: boolean) => {
     if (isChecked) {
-      setSelectedApplications((prev) => [...prev, id]);
+      setCheckedApplications((prev) => [...prev, id]);
     } else {
-      setSelectedApplications((prev) => prev.filter((item) => item !== id));
+      setCheckedApplications((prev) => prev.filter((item) => item !== id));
     }
   };
 
@@ -78,7 +75,7 @@ const ApplicationStatusPage = () => {
   };
 
   const handleOpenForm = () => {
-    setOpenForm(true);
+    setIsFormOpen(true);
   };
 
   useEffect(() => {
@@ -107,9 +104,9 @@ const ApplicationStatusPage = () => {
             <div className="w-full">
               <div className="overflow-x-auto no-scrollbar hidden lg:block">
                 <SubTap
-                  optionData={OPTIONS}
-                  selectedOption={option}
-                  handleOption={setOption}
+                  optionData={FILTER_TABS}
+                  selectedOption={selectedFilter}
+                  handleOption={(label: string) => setSelectedFilter(label)}
                 />
               </div>
 
@@ -130,16 +127,21 @@ const ApplicationStatusPage = () => {
                   />
                   <div className="lg:hidden flex items-center">
                     <PullDown
-                      optionData={MOBILE_OPTIONS}
+                      optionData={MOBILE_FILTER_TABS}
                       multiple={false}
-                      selectedOption={selectedSortOption}
-                      handleOption={setSelectedSortOption}
+                      selectedOption={[selectedFilter]}
+                      handleOption={(label: string[]) => {
+                        if (label[0] !== "지원 상태") {
+                          setSelectedFilter(label[0]);
+                        } else return;
+                      }}
                       optionSize={"small"}
                     />
                   </div>
                   <div className="smm:block hidden">
                     <RangeCalendar />
                   </div>
+
                   <SubSearchInput
                     onSearch={() => {}}
                     placeholder={"이름 또는 공고 제목"}
@@ -162,13 +164,13 @@ const ApplicationStatusPage = () => {
                 >
                   <AllCheckBox
                     isChecked={
-                      selectedApplications.length ===
+                      checkedApplications.length ===
                       APPLICATION_FORM_DATA.length
                     }
                     label={"전체 선택"}
                     onClick={() =>
                       handleAllCheck(
-                        selectedApplications.length !==
+                        checkedApplications.length !==
                           APPLICATION_FORM_DATA.length
                       )
                     }
@@ -185,13 +187,8 @@ const ApplicationStatusPage = () => {
                         className="absolute top-full mt-2 z-50 left-12"
                       >
                         <SingleSelectOptions
-                          selectedOption={selectedOption}
-                          optionData={[
-                            { id: 1, label: "합격" },
-                            { id: 2, label: "불합격" },
-                            { id: 3, label: "대기중" },
-                            { id: 4, label: "면접중" },
-                          ]}
+                          selectedOption={""}
+                          optionData={OPTIONS}
                           size="medium"
                           handleMenuClick={handleMenuClick}
                         />
@@ -203,13 +200,13 @@ const ApplicationStatusPage = () => {
                 <div className="flex justify-between mb-4">
                   <AllCheckBox
                     isChecked={
-                      selectedApplications.length ===
+                      checkedApplications.length ===
                       APPLICATION_FORM_DATA.length
                     }
                     label={"전체 선택"}
                     onClick={() =>
                       handleAllCheck(
-                        selectedApplications.length !==
+                        checkedApplications.length !==
                           APPLICATION_FORM_DATA.length
                       )
                     }
@@ -234,7 +231,7 @@ const ApplicationStatusPage = () => {
                       serviceNickname={item.nickname}
                       status={item.status}
                       recruitmentTitle={item.jobTitle}
-                      isChecked={selectedApplications.includes(item.id)}
+                      isChecked={checkedApplications.includes(item.id)}
                       onClick={handleOpenForm}
                       onCheck={(isChecked) =>
                         handleSingleCheck(item.id, isChecked)
@@ -249,16 +246,12 @@ const ApplicationStatusPage = () => {
             </div>
           </div>
         </div>
-        {isMdUp ? openForm && null : openForm && null}
+        {isMdUp ? isFormOpen && null : isFormOpen && null}
         {isOptionsOpen && !isMdUp && (
           <CommonBottomSheet
             optionData={OPTIONS}
-            selectedOption={selectedStatus}
-            handleMenuClick={(label: string) => {
-              setSelectedStatus(label);
-              setIsOptionsOpen(false);
-              setIsModalOpen(true);
-            }}
+            selectedOption={""}
+            handleMenuClick={handleMenuClick}
             onClose={() => setIsOptionsOpen(false)}
           />
         )}

--- a/app/(club)/club/management/recruitment/applicationStatus/page.tsx
+++ b/app/(club)/club/management/recruitment/applicationStatus/page.tsx
@@ -133,15 +133,6 @@ const ApplicationStatusPage = () => {
     setCheckedApplications([]);
   };
 
-  // 지원 상태 변경 옵션 목록 중 메뉴 클릭
-  // const handleMenuClick = (label: string) => {
-  //   setIsOptionsOpen(false);
-  //   if (!checkedApplications.length) {
-  //     setAlertMessage("선택된 지원서가 없습니다.");
-  //     return;
-  //   }
-  // };
-
   // 지원 상태 변경 확인 모달 내 '변경하기' 버튼 클릭
   const handleStatusChange = () => {
     if (!selectedOption) return;

--- a/app/(club)/club/management/recruitment/applicationStatus/page.tsx
+++ b/app/(club)/club/management/recruitment/applicationStatus/page.tsx
@@ -305,7 +305,7 @@ const ApplicationStatusPage = () => {
                       key={item.id}
                       applyInfo={item}
                       isChecked={checkedApplications.includes(item.id)}
-                      onClick={handleOpenForm}
+                      setOpenOptions={() => setIsOptionsOpen(!isOptionsOpen)}
                       onCheck={(isChecked) =>
                         handleSingleCheck(item.id, isChecked)
                       }

--- a/app/api/apply/api.ts
+++ b/app/api/apply/api.ts
@@ -310,14 +310,28 @@ export const getApplicationDetail = async (applyId: string) => {
 export type UpdateApplicationStatusParams = {
   applications: string[];
   type: StatusValue;
+  interviewMessage?: string;
+};
+
+const getRequestBody = (
+  type: StatusValue,
+  applications: string[],
+  interviewMessage?: string
+) => {
+  if (type === "interview") {
+    return { applyIds: applications, interviewMessage };
+  }
+  return applications;
 };
 
 export const updateApplicationStatus = async ({
   applications,
   type,
+  interviewMessage,
 }: UpdateApplicationStatusParams) => {
   try {
-    const res = await axiosInstance.post(`/applies/${type}`, applications);
+    const body = getRequestBody(type, applications, interviewMessage);
+    const res = await axiosInstance.post(`/applies/${type}`, body);
     return res.data;
   } catch (error) {
     console.log("Failed to update application status", error);

--- a/app/api/apply/api.ts
+++ b/app/api/apply/api.ts
@@ -16,6 +16,7 @@ import {
   ApplyDetailRes,
   ApplyListRes,
 } from "@/types/application";
+import { StatusValue } from "@/constants/application";
 
 import { IdResponse } from "@/types/api";
 import {
@@ -301,6 +302,25 @@ export const getApplicationDetail = async (applyId: string) => {
     return res.data;
   } catch (error) {
     console.log("Error fetching application detail");
+    throw error;
+  }
+};
+
+// 지원현황 - 지원 상태 변경(관리자)
+export type UpdateApplicationStatusParams = {
+  applications: string[];
+  type: StatusValue;
+};
+
+export const updateApplicationStatus = async ({
+  applications,
+  type,
+}: UpdateApplicationStatusParams) => {
+  try {
+    const res = await axiosInstance.post(`/applies/${type}`, applications);
+    return res.data;
+  } catch (error) {
+    console.log("Failed to update application status", error);
     throw error;
   }
 };

--- a/app/api/apply/api.ts
+++ b/app/api/apply/api.ts
@@ -16,6 +16,7 @@ import {
   ApplyFormData,
   ApplyFormRes,
   ApplyListRes,
+  ApplyDetailRes,
   ApplySaveReq,
   ApplyTempListRes,
   ApplyTempDetailRes,
@@ -246,5 +247,16 @@ export const getApplicationsList = async (
       applyDataList: [],
       pageInfo: { contentSize: 0, totalSize: 0, totalPages: 0 },
     };
+  }
+};
+
+// 지원현황 - 지원서 상세 조회
+export const getApplicationDetail = async (applyId: string) => {
+  try {
+    const res = await axiosInstance.get<ApplyDetailRes>(`/applies/${applyId}`);
+    return res.data;
+  } catch (error) {
+    console.log("Error fetching application detail");
+    throw error;
   }
 };

--- a/app/api/apply/api.ts
+++ b/app/api/apply/api.ts
@@ -11,7 +11,11 @@ import {
 } from "../apiUrl";
 import { APPLY_TEMPS_MY } from "../apiUrl";
 import axiosInstance from "../axiosInstance";
-import { ApplicationListConditionReq, ApplyListRes } from "@/types/application";
+import {
+  ApplicationListConditionReq,
+  ApplyDetailRes,
+  ApplyListRes,
+} from "@/types/application";
 
 import { IdResponse } from "@/types/api";
 import {
@@ -287,5 +291,16 @@ export const getApplicationsList = async (
       applyDataList: [],
       pageInfo: { contentSize: 0, totalSize: 0, totalPages: 0 },
     };
+  }
+};
+
+// 지원현황 - 지원서 상세 조회
+export const getApplicationDetail = async (applyId: string) => {
+  try {
+    const res = await axiosInstance.get<ApplyDetailRes>(`/applies/${applyId}`);
+    return res.data;
+  } catch (error) {
+    console.log("Error fetching application detail");
+    throw error;
   }
 };

--- a/app/api/apply/api.ts
+++ b/app/api/apply/api.ts
@@ -276,7 +276,7 @@ export const getApplicationsList = async (
         params: {
           ...condition,
           page: page,
-          size: 1,
+          size: 10,
         },
       }
     );

--- a/app/api/apply/api.ts
+++ b/app/api/apply/api.ts
@@ -235,7 +235,7 @@ export const getApplicationsList = async (
         params: {
           ...condition,
           page: page,
-          size: 1,
+          size: 10,
         },
       }
     );

--- a/app/api/apply/api.ts
+++ b/app/api/apply/api.ts
@@ -9,13 +9,8 @@ import {
   CLUBS,
   RECRUITMENT,
 } from "../apiUrl";
-import { APPLY_TEMPS_MY } from "../apiUrl";
 import axiosInstance from "../axiosInstance";
-import {
-  ApplicationListConditionReq,
-  ApplyDetailRes,
-  ApplyListRes,
-} from "@/types/application";
+
 import { StatusValue } from "@/constants/application";
 
 import { IdResponse } from "@/types/api";
@@ -227,44 +222,6 @@ export const putApplicationTemp = async (
       }
     }
     throw new Error("문제가 발생했습니다.");
-  }
-};
-
-// 동아리 상세 - 지원 현황 리스트
-export const getApplicationsList = async (
-  clubId: string,
-  condition: ApplicationListConditionReq,
-  page: Pageable["page"]
-) => {
-  try {
-    const res = await axiosInstance.get<ApplyListRes>(
-      `club/${clubId}/applies`,
-      {
-        params: {
-          ...condition,
-          page: page,
-          size: 10,
-        },
-      }
-    );
-    return res.data;
-  } catch (error) {
-    console.log("Error fetching applications list", error);
-    return {
-      applyDataList: [],
-      pageInfo: { contentSize: 0, totalSize: 0, totalPages: 0 },
-    };
-  }
-};
-
-// 지원현황 - 지원서 상세 조회
-export const getApplicationDetail = async (applyId: string) => {
-  try {
-    const res = await axiosInstance.get<ApplyDetailRes>(`/applies/${applyId}`);
-    return res.data;
-  } catch (error) {
-    console.log("Error fetching application detail");
-    throw error;
   }
 };
 

--- a/app/api/apply/api.ts
+++ b/app/api/apply/api.ts
@@ -9,7 +9,9 @@ import {
   CLUBS,
   RECRUITMENT,
 } from "../apiUrl";
+import { APPLY_TEMPS_MY } from "../apiUrl";
 import axiosInstance from "../axiosInstance";
+import { ApplicationListConditionReq, ApplyListRes } from "@/types/application";
 
 import { IdResponse } from "@/types/api";
 import {
@@ -258,5 +260,32 @@ export const getApplicationDetail = async (applyId: string) => {
   } catch (error) {
     console.log("Error fetching application detail");
     throw error;
+  }
+};
+
+// 동아리 상세 - 지원 현황 리스트
+export const getApplicationsList = async (
+  clubId: string,
+  condition: ApplicationListConditionReq,
+  page: Pageable["page"]
+) => {
+  try {
+    const res = await axiosInstance.get<ApplyListRes>(
+      `club/${clubId}/applies`,
+      {
+        params: {
+          ...condition,
+          page: page,
+          size: 1,
+        },
+      }
+    );
+    return res.data;
+  } catch (error) {
+    console.log("Error fetching applications list", error);
+    return {
+      applyDataList: [],
+      pageInfo: { contentSize: 0, totalSize: 0, totalPages: 0 },
+    };
   }
 };

--- a/app/api/apply/api.ts
+++ b/app/api/apply/api.ts
@@ -1,3 +1,4 @@
+import { Pageable } from "@/types/api";
 import { AxiosError } from "axios";
 import {
   APPLY,
@@ -18,6 +19,7 @@ import {
   ApplySaveReq,
   ApplyTempListRes,
   ApplyTempDetailRes,
+  ApplicationListConditionReq,
 } from "@/types/application";
 
 export const getAppliedList = async (
@@ -217,5 +219,32 @@ export const putApplicationTemp = async (
       }
     }
     throw new Error("문제가 발생했습니다.");
+  }
+};
+
+// 동아리 상세 - 지원 현황 리스트
+export const getApplicationsList = async (
+  clubId: string,
+  condition: ApplicationListConditionReq,
+  page: Pageable["page"]
+) => {
+  try {
+    const res = await axiosInstance.get<ApplyListRes>(
+      `club/${clubId}/applies`,
+      {
+        params: {
+          ...condition,
+          page: page,
+          size: 1,
+        },
+      }
+    );
+    return res.data;
+  } catch (error) {
+    console.log("Error fetching applications list", error);
+    return {
+      applyDataList: [],
+      pageInfo: { contentSize: 0, totalSize: 0, totalPages: 0 },
+    };
   }
 };

--- a/app/api/apply/api.ts
+++ b/app/api/apply/api.ts
@@ -10,12 +10,6 @@ import {
   RECRUITMENT,
 } from "../apiUrl";
 import axiosInstance from "../axiosInstance";
-import {
-  ApplicationListConditionReq,
-  ApplyDetailRes,
-  ApplyListRes,
-} from "@/types/application";
-import { StatusValue } from "@/constants/application";
 
 import { StatusValue } from "@/constants/application";
 

--- a/app/components/bottomSheet/interviewNoticeBottomSheet.tsx
+++ b/app/components/bottomSheet/interviewNoticeBottomSheet.tsx
@@ -4,13 +4,13 @@ import close from "@/images/icon/close.svg";
 import help from "@/images/icon/help.svg";
 import LargeBtn from "../button/basicBtn/largeBtn";
 import Alert from "../alert/alert";
-import { InterviewNoticeProps } from "@/types/components/review";
 import Contour from "../bar/contour";
+import { InterviewNoticeModalProps } from "../modal/club/interviewNoticeModal";
 
 const InterviewNoticeBottomSheet = ({
   onClose,
   onSubmit,
-}: InterviewNoticeProps) => {
+}: InterviewNoticeModalProps) => {
   const [isVisible, setIsVisible] = useState<boolean>(false);
   const [details, setDetails] = useState<string>("");
   const [alertMessage, setAlertMessage] = useState<string | null>(null);
@@ -29,7 +29,7 @@ const InterviewNoticeBottomSheet = ({
 
   const handleSubmit = () => {
     if (validateForm()) {
-      onSubmit();
+      onSubmit(details);
       onClose();
     }
   };

--- a/app/components/calendar/rangeCalendar.tsx
+++ b/app/components/calendar/rangeCalendar.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from "react";
+import React from "react";
 import DatePicker from "react-datepicker";
 import "react-datepicker/dist/react-datepicker.css";
 import "../../../public/style/custom.css";
@@ -8,29 +8,21 @@ import calendarIcon from "@/images/icon/calender.svg";
 interface CustomCalendarProps {
   placeholder?: string;
   onDateChange?: (date: [Date | null, Date | null]) => void;
+  selectedRange: [Date | null, Date | null];
 }
 
 /**
  * 조회 기간을 선택하는 캘린더
  * @param placeholder
  * @param onDateChange 데이터 변경 핸들러
+ * @param selectedRange
  * @returns
  */
 const RangeCalendar = ({
   placeholder = "조회기간",
   onDateChange,
+  selectedRange,
 }: CustomCalendarProps) => {
-  const [selectedRange, setSelectedRange] = useState<
-    [Date | null, Date | null]
-  >([null, null]);
-
-  const handleDateChange = (dates: [Date | null, Date | null]) => {
-    setSelectedRange(dates);
-    if (onDateChange) {
-      onDateChange(dates);
-    }
-  };
-
   const formatDate = (date: Date | null): string => {
     return date
       ? date
@@ -52,7 +44,7 @@ const RangeCalendar = ({
     <div className="relative md:h-[44px]">
       <DatePicker
         selected={selectedRange[0]}
-        onChange={handleDateChange}
+        onChange={onDateChange}
         startDate={selectedRange[0]}
         endDate={selectedRange[1]}
         selectsRange={true}

--- a/app/components/card/applicationFormCard.tsx
+++ b/app/components/card/applicationFormCard.tsx
@@ -10,7 +10,7 @@ import ApplicationFormPreviewModal from "../modal/club/applicationFormViewModal"
 import testImage from "@/images/icon/calender.svg";
 import MobileApplicationFormViewModal from "../modal/club/mobileApplicationFormViewModal";
 import { ApplyData } from "@/types/application";
-import { APPLY_STATUS } from "@/constants/application";
+import { APPLY_STATUS_MAP } from "@/constants/application";
 
 interface ApplicationFormCardProps {
   applyInfo: ApplyData;
@@ -36,7 +36,7 @@ const ApplicationFormCard = ({
   onCheck,
 }: ApplicationFormCardProps) => {
   const { id, memberData, name, applyStatusType, recruitmentTitle } = applyInfo;
-  const applyStatus = APPLY_STATUS[applyStatusType];
+  const applyStatus = APPLY_STATUS_MAP[applyStatusType];
 
   const isMdUp = useResponsive("md");
 

--- a/app/components/card/applicationFormCard.tsx
+++ b/app/components/card/applicationFormCard.tsx
@@ -35,7 +35,7 @@ const ApplicationFormCard = ({
   onClick,
   onCheck,
 }: ApplicationFormCardProps) => {
-  const { id, clubName, name, applyStatusType, recruitmentTitle } = applyInfo;
+  const { id, memberData, name, applyStatusType, recruitmentTitle } = applyInfo;
   const applyStatus = APPLY_STATUS[applyStatusType];
 
   const isMdUp = useResponsive("md");
@@ -67,7 +67,7 @@ const ApplicationFormCard = ({
             <div className="flex flex-col items-center gap-1 md:flex-row md:gap-3">
               <CheckBox
                 isChecked={isChecked}
-                label={clubName}
+                label={memberData.nickname}
                 onClick={() => onCheck(!isChecked)}
               />
               <p className="text-subtext2 self-start text-mobile_body2_m md:text-body3_m md:self-center">

--- a/app/components/card/applicationFormCard.tsx
+++ b/app/components/card/applicationFormCard.tsx
@@ -33,12 +33,6 @@ const ApplicationFormCard = ({
   const [openNoticeModal, setOpenNoticeModal] = useState<boolean>(false);
   const [alertMessage, setAlertMessage] = useState<string | null>(null);
 
-  const handleBadgeClick = () => {
-    if (applyStatus === "대기중") {
-      setOpenNoticeModal(true);
-    }
-  };
-
   const handleSubmitSuccess = () => {
     setAlertMessage("면접 안내를 전송했습니다.");
     setOpenNoticeModal(false);
@@ -63,12 +57,7 @@ const ApplicationFormCard = ({
                 {name}
               </p>
             </div>
-            <div
-              onClick={handleBadgeClick}
-              className={`${applyStatus === "대기중" && "cursor-pointer"}`}
-            >
-              <ResultBadge status={applyStatus} />
-            </div>
+            <ResultBadge status={applyStatus} />
           </div>
           <div className="flex justify-between gap-3">
             <p className="text-mobile_body3_r md:text-body2_m text-subtext2 w-full bg-sub_bg p-2.5 rounded-lg md:py-2 md:px-3">

--- a/app/components/card/applicationFormCard.tsx
+++ b/app/components/card/applicationFormCard.tsx
@@ -9,21 +9,20 @@ import Alert from "../alert/alert";
 import ApplicationFormPreviewModal from "../modal/club/applicationFormViewModal";
 import testImage from "@/images/icon/calender.svg";
 import MobileApplicationFormViewModal from "../modal/club/mobileApplicationFormViewModal";
+import { ApplyData } from "@/types/application";
+import { APPLY_STATUS } from "@/constants/application";
 
 interface ApplicationFormCardProps {
-  clubName: string;
-  serviceNickname: string;
-  status: "합격" | "불합격" | "대기중" | "면접중";
-  recruitmentTitle: string;
+  applyInfo: ApplyData;
   isChecked: boolean;
   onClick: () => void;
   onCheck: (isChecked: boolean) => void;
 }
 
 const SAMOLE_DATA = [
-  { label: "이름", value: "김아리" },
-  { label: "성별", value: "남자" },
-  { label: "생년월일", value: "2000년 00월 00일" },
+  { label: "이름", key: "name" },
+  { label: "성별", key: "name" },
+  { label: "생년월일", key: "name" },
   { label: "연락처", value: "010-0000-0000" },
   { label: "이메일", value: "example@gmail.com" },
   { label: "자유 항목 제목 1", value: "Default Text" },
@@ -31,14 +30,14 @@ const SAMOLE_DATA = [
 ];
 
 const ApplicationFormCard = ({
-  clubName,
-  serviceNickname,
-  status,
-  recruitmentTitle,
+  applyInfo,
   isChecked,
   onClick,
   onCheck,
 }: ApplicationFormCardProps) => {
+  const { id, clubName, name, applyStatusType, recruitmentTitle } = applyInfo;
+  const applyStatus = APPLY_STATUS[applyStatusType];
+
   const isMdUp = useResponsive("md");
 
   const [openFormModal, setOpenFormModal] = useState<boolean>(false);
@@ -72,14 +71,14 @@ const ApplicationFormCard = ({
                 onClick={() => onCheck(!isChecked)}
               />
               <p className="text-subtext2 self-start text-mobile_body2_m md:text-body3_m md:self-center">
-                {serviceNickname}
+                {name}
               </p>
             </div>
             <div
               onClick={handleBadgeClick}
-              className={`${status === "대기중" && "cursor-pointer"}`}
+              className={`${applyStatus === "대기중" && "cursor-pointer"}`}
             >
-              <ResultBadge status={status} />
+              <ResultBadge status={applyStatus} />
             </div>
           </div>
           <div className="flex justify-between gap-3">
@@ -117,13 +116,13 @@ const ApplicationFormCard = ({
       {isMdUp
         ? openFormModal && (
             <ApplicationFormPreviewModal
+              applyId={id}
               onClose={() => setOpenFormModal(false)}
               data={{
                 name: "김아리",
                 image: testImage,
                 nickname: "백설공주",
               }}
-              fields={SAMOLE_DATA}
               portfolio={true}
               portfolioData={{
                 portfolioPurpose: "프로젝트 목적s",
@@ -134,13 +133,13 @@ const ApplicationFormCard = ({
           )
         : openFormModal && (
             <MobileApplicationFormViewModal
+              applyId={id}
               onClose={() => setOpenFormModal(false)}
               data={{
                 name: "김아리",
                 image: testImage,
                 nickname: "백설공주",
               }}
-              fields={SAMOLE_DATA}
               portfolio={true}
               portfolioData={{
                 portfolioPurpose: "프로젝트 목적s",

--- a/app/components/card/applicationFormCard.tsx
+++ b/app/components/card/applicationFormCard.tsx
@@ -118,34 +118,12 @@ const ApplicationFormCard = ({
             <ApplicationFormPreviewModal
               applyId={id}
               onClose={() => setOpenFormModal(false)}
-              data={{
-                name: "김아리",
-                image: testImage,
-                nickname: "백설공주",
-              }}
-              portfolio={true}
-              portfolioData={{
-                portfolioPurpose: "프로젝트 목적s",
-                portfolioText: "포트폴리오 내용",
-                portfolioFile: "file.pdf",
-              }}
             />
           )
         : openFormModal && (
             <MobileApplicationFormViewModal
               applyId={id}
               onClose={() => setOpenFormModal(false)}
-              data={{
-                name: "김아리",
-                image: testImage,
-                nickname: "백설공주",
-              }}
-              portfolio={true}
-              portfolioData={{
-                portfolioPurpose: "프로젝트 목적s",
-                portfolioText: "포트폴리오 내용",
-                portfolioFile: "file.pdf",
-              }}
             />
           )}
 

--- a/app/components/card/applicationFormCard.tsx
+++ b/app/components/card/applicationFormCard.tsx
@@ -7,7 +7,6 @@ import useResponsive from "@/hooks/useResponsive";
 import InterviewNoticeBottomSheet from "../bottomSheet/interviewNoticeBottomSheet";
 import Alert from "../alert/alert";
 import ApplicationFormPreviewModal from "../modal/club/applicationFormViewModal";
-import testImage from "@/images/icon/calender.svg";
 import MobileApplicationFormViewModal from "../modal/club/mobileApplicationFormViewModal";
 import { ApplyData } from "@/types/application";
 import { APPLY_STATUS_MAP } from "@/constants/application";
@@ -15,24 +14,14 @@ import { APPLY_STATUS_MAP } from "@/constants/application";
 interface ApplicationFormCardProps {
   applyInfo: ApplyData;
   isChecked: boolean;
-  onClick: () => void;
+  setOpenOptions: () => void;
   onCheck: (isChecked: boolean) => void;
 }
-
-const SAMOLE_DATA = [
-  { label: "이름", key: "name" },
-  { label: "성별", key: "name" },
-  { label: "생년월일", key: "name" },
-  { label: "연락처", value: "010-0000-0000" },
-  { label: "이메일", value: "example@gmail.com" },
-  { label: "자유 항목 제목 1", value: "Default Text" },
-  { label: "자유 항목 제목 2", value: "Default Text" },
-];
 
 const ApplicationFormCard = ({
   applyInfo,
   isChecked,
-  onClick,
+  setOpenOptions,
   onCheck,
 }: ApplicationFormCardProps) => {
   const { id, memberData, name, applyStatusType, recruitmentTitle } = applyInfo;
@@ -45,7 +34,7 @@ const ApplicationFormCard = ({
   const [alertMessage, setAlertMessage] = useState<string | null>(null);
 
   const handleBadgeClick = () => {
-    if (status === "대기중") {
+    if (applyStatus === "대기중") {
       setOpenNoticeModal(true);
     }
   };
@@ -123,6 +112,7 @@ const ApplicationFormCard = ({
         : openFormModal && (
             <MobileApplicationFormViewModal
               applyId={id}
+              onOpenStatusOptions={setOpenOptions}
               onClose={() => setOpenFormModal(false)}
             />
           )}

--- a/app/components/card/applicationFormCard.tsx
+++ b/app/components/card/applicationFormCard.tsx
@@ -2,44 +2,33 @@ import { useState } from "react";
 import ResultBadge from "../badge/resultBadge";
 import TransparentSmallBtn from "../button/basicBtn/transparentSmallBtn";
 import CheckBox from "../checkBox/checkBox";
-import InterviewNoticeModal from "../modal/club/interviewNoticeModal";
-import useResponsive from "@/hooks/useResponsive";
-import InterviewNoticeBottomSheet from "../bottomSheet/interviewNoticeBottomSheet";
 import Alert from "../alert/alert";
-import ApplicationFormPreviewModal from "../modal/club/applicationFormViewModal";
-import MobileApplicationFormViewModal from "../modal/club/mobileApplicationFormViewModal";
 import { ApplyData } from "@/types/application";
 import { APPLY_STATUS_MAP } from "@/constants/application";
 
 interface ApplicationFormCardProps {
   applyInfo: ApplyData;
   isChecked: boolean;
-  setOpenOptions: () => void;
   onCheck: (isChecked: boolean) => void;
+  setOpenApplication: (id: string) => void;
 }
 
 const ApplicationFormCard = ({
   applyInfo,
   isChecked,
-  setOpenOptions,
   onCheck,
+  setOpenApplication,
 }: ApplicationFormCardProps) => {
   const { id, memberData, name, applyStatusType, recruitmentTitle } = applyInfo;
   const applyStatus = APPLY_STATUS_MAP[applyStatusType];
-
-  const isMdUp = useResponsive("md");
-
-  const [openFormModal, setOpenFormModal] = useState<boolean>(false);
-  const [openNoticeModal, setOpenNoticeModal] = useState<boolean>(false);
   const [alertMessage, setAlertMessage] = useState<string | null>(null);
 
-  const handleSubmitSuccess = () => {
-    setAlertMessage("면접 안내를 전송했습니다.");
-    setOpenNoticeModal(false);
-  };
+  // const handleSubmitSuccess = () => {
+  //   setAlertMessage("면접 안내를 전송했습니다.");
+  // };
 
   const handleView = () => {
-    setOpenFormModal(true);
+    setOpenApplication(id);
   };
 
   return (
@@ -78,33 +67,6 @@ const ApplicationFormCard = ({
           className="hidden md:block"
         />
       </div>
-      {isMdUp
-        ? openNoticeModal && (
-            <InterviewNoticeModal
-              onClose={() => setOpenNoticeModal(false)}
-              onSubmit={handleSubmitSuccess}
-            />
-          )
-        : openNoticeModal && (
-            <InterviewNoticeBottomSheet
-              onClose={() => setOpenNoticeModal(false)}
-              onSubmit={handleSubmitSuccess}
-            />
-          )}
-      {isMdUp
-        ? openFormModal && (
-            <ApplicationFormPreviewModal
-              applyId={id}
-              onClose={() => setOpenFormModal(false)}
-            />
-          )
-        : openFormModal && (
-            <MobileApplicationFormViewModal
-              applyId={id}
-              onOpenStatusOptions={setOpenOptions}
-              onClose={() => setOpenFormModal(false)}
-            />
-          )}
 
       {alertMessage && (
         <Alert text={alertMessage} onClose={() => setAlertMessage(null)} />

--- a/app/components/dropdown/UpdateApplyStatusOptions.tsx
+++ b/app/components/dropdown/UpdateApplyStatusOptions.tsx
@@ -4,28 +4,25 @@ import vector from "@/images/icon/sub_pull_down.svg";
 import { STATUS_OPTIONS } from "@/(club)/club/management/recruitment/applicationStatus/page";
 import useResponsive from "@/hooks/useResponsive";
 import CommonBottomSheet from "../bottomSheet/commonBottomSheet";
+import { useEffect, useRef, useState } from "react";
 
 interface UpdateApplyStatusOptionsProps {
-  isOptionsOpen: boolean;
-  setIsOptionsOpen: (isOpen: boolean) => void;
   checkedApplications: string[];
   setAlertMessage?: (message: string) => void;
   setSelectedStatus: (status: string) => void;
   setIsModalOpen: (isOpen: boolean) => void;
-  optionsRef: React.RefObject<HTMLDivElement>;
 }
 
 // 지원상태 변경 옵션 open trigger(공통 버튼+dropdown/bottomSheet)
 const UpdateApplyStatusOptions = ({
-  isOptionsOpen,
-  setIsOptionsOpen,
   checkedApplications,
   setAlertMessage,
   setSelectedStatus,
   setIsModalOpen,
-  optionsRef,
 }: UpdateApplyStatusOptionsProps) => {
+  const optionsRef = useRef<HTMLDivElement>(null);
   const isMdUp = useResponsive("md");
+  const [isOptionsOpen, setIsOptionsOpen] = useState<boolean>(false);
 
   // 지원 상태 변경 옵션 목록 중 메뉴 클릭
   const handleMenuClick = (label: string) => {
@@ -37,6 +34,21 @@ const UpdateApplyStatusOptions = ({
     setSelectedStatus(label);
     setIsModalOpen(true);
   };
+
+  useEffect(() => {
+    const handleClickOutside = (event: MouseEvent) => {
+      if (
+        optionsRef.current &&
+        !optionsRef.current.contains(event.target as Node)
+      ) {
+        setIsOptionsOpen(false);
+      }
+    };
+    document.addEventListener("mousedown", handleClickOutside);
+    return () => {
+      document.removeEventListener("mousedown", handleClickOutside);
+    };
+  }, []);
 
   return (
     <>

--- a/app/components/dropdown/UpdateApplyStatusOptions.tsx
+++ b/app/components/dropdown/UpdateApplyStatusOptions.tsx
@@ -1,0 +1,93 @@
+import Image from "next/image";
+import SingleSelectOptions from "../pulldown/singleSelectOptions";
+import vector from "@/images/icon/sub_pull_down.svg";
+import { useEffect, useRef } from "react";
+import { STATUS_OPTIONS } from "@/(club)/club/management/recruitment/applicationStatus/page";
+import useResponsive from "@/hooks/useResponsive";
+import CommonBottomSheet from "../bottomSheet/commonBottomSheet";
+
+interface UpdateApplyStatusOptionsProps {
+  isOptionsOpen: boolean;
+  setIsOptionsOpen: (isOpen: boolean) => void;
+  checkedApplications: string[];
+  setAlertMessage: (message: string) => void;
+  setSelectedStatus: (status: string) => void;
+  setIsModalOpen: (isOpen: boolean) => void;
+}
+
+// 지원상태 변경 옵션 open trigger(공통 버튼+dropdown/bottomSheet)
+const UpdateApplyStatusOptions = ({
+  isOptionsOpen,
+  setIsOptionsOpen,
+  checkedApplications,
+  setAlertMessage,
+  setSelectedStatus,
+  setIsModalOpen,
+}: UpdateApplyStatusOptionsProps) => {
+  const optionsRef = useRef<HTMLDivElement | null>(null);
+  const isMdUp = useResponsive("md");
+
+  // 지원 상태 변경 옵션 목록 중 메뉴 클릭
+  const handleMenuClick = (label: string) => {
+    setIsOptionsOpen(false);
+    if (!checkedApplications.length) {
+      setAlertMessage("선택된 지원서가 없습니다.");
+      return;
+    }
+    setSelectedStatus(label);
+    setIsOptionsOpen(false);
+  };
+
+  useEffect(() => {
+    const handleClickOutside = (event: MouseEvent) => {
+      if (
+        optionsRef.current &&
+        !optionsRef.current.contains(event.target as Node)
+      ) {
+        setIsOptionsOpen(false);
+      }
+    };
+    document.addEventListener("mousedown", handleClickOutside);
+    return () => {
+      document.removeEventListener("mousedown", handleClickOutside);
+    };
+  }, []);
+
+  return (
+    <>
+      <div className="relative">
+        <button
+          className="relative flex items-center gap-2 cursor-pointer md:text-body1_m text-mobile_body2_m text-subtext2"
+          onClick={() => setIsOptionsOpen(!isOptionsOpen)}
+        >
+          <p>지원상태 변경</p>
+          <Image alt={"버튼"} src={vector} width={28} height={28} />
+        </button>
+
+        {isOptionsOpen &&
+          (isMdUp ? (
+            <div
+              ref={optionsRef}
+              className="absolute top-full mt-2 z-50 left-12"
+            >
+              <SingleSelectOptions
+                selectedOption={""}
+                optionData={STATUS_OPTIONS}
+                size="medium"
+                handleMenuClick={handleMenuClick}
+              />
+            </div>
+          ) : (
+            <CommonBottomSheet
+              optionData={STATUS_OPTIONS}
+              selectedOption={""}
+              handleMenuClick={handleMenuClick}
+              onClose={() => setIsOptionsOpen(false)}
+            />
+          ))}
+      </div>
+    </>
+  );
+};
+
+export default UpdateApplyStatusOptions;

--- a/app/components/dropdown/UpdateApplyStatusOptions.tsx
+++ b/app/components/dropdown/UpdateApplyStatusOptions.tsx
@@ -1,7 +1,6 @@
 import Image from "next/image";
 import SingleSelectOptions from "../pulldown/singleSelectOptions";
 import vector from "@/images/icon/sub_pull_down.svg";
-import { useEffect, useRef } from "react";
 import { STATUS_OPTIONS } from "@/(club)/club/management/recruitment/applicationStatus/page";
 import useResponsive from "@/hooks/useResponsive";
 import CommonBottomSheet from "../bottomSheet/commonBottomSheet";
@@ -10,9 +9,10 @@ interface UpdateApplyStatusOptionsProps {
   isOptionsOpen: boolean;
   setIsOptionsOpen: (isOpen: boolean) => void;
   checkedApplications: string[];
-  setAlertMessage: (message: string) => void;
+  setAlertMessage?: (message: string) => void;
   setSelectedStatus: (status: string) => void;
   setIsModalOpen: (isOpen: boolean) => void;
+  optionsRef: React.RefObject<HTMLDivElement>;
 }
 
 // 지원상태 변경 옵션 open trigger(공통 버튼+dropdown/bottomSheet)
@@ -23,47 +23,33 @@ const UpdateApplyStatusOptions = ({
   setAlertMessage,
   setSelectedStatus,
   setIsModalOpen,
+  optionsRef,
 }: UpdateApplyStatusOptionsProps) => {
-  const optionsRef = useRef<HTMLDivElement | null>(null);
   const isMdUp = useResponsive("md");
 
   // 지원 상태 변경 옵션 목록 중 메뉴 클릭
   const handleMenuClick = (label: string) => {
     setIsOptionsOpen(false);
     if (!checkedApplications.length) {
-      setAlertMessage("선택된 지원서가 없습니다.");
+      setAlertMessage?.("선택된 지원서가 없습니다.");
       return;
     }
     setSelectedStatus(label);
-    setIsOptionsOpen(false);
+    setIsModalOpen(true);
   };
-
-  useEffect(() => {
-    const handleClickOutside = (event: MouseEvent) => {
-      if (
-        optionsRef.current &&
-        !optionsRef.current.contains(event.target as Node)
-      ) {
-        setIsOptionsOpen(false);
-      }
-    };
-    document.addEventListener("mousedown", handleClickOutside);
-    return () => {
-      document.removeEventListener("mousedown", handleClickOutside);
-    };
-  }, []);
 
   return (
     <>
       <div className="relative">
         <button
           className="relative flex items-center gap-2 cursor-pointer md:text-body1_m text-mobile_body2_m text-subtext2"
-          onClick={() => setIsOptionsOpen(!isOptionsOpen)}
+          onClick={() => {
+            setIsOptionsOpen(!isOptionsOpen);
+          }}
         >
           <p>지원상태 변경</p>
           <Image alt={"버튼"} src={vector} width={28} height={28} />
         </button>
-
         {isOptionsOpen &&
           (isMdUp ? (
             <div

--- a/app/components/input/subSearchInput.tsx
+++ b/app/components/input/subSearchInput.tsx
@@ -45,7 +45,7 @@ const SubSearchInput = ({
         md:text-body1_r focus:outline-none rounded-3xl"
         onKeyDown={(e) => {
           if (e.key === "Enter") {
-            onSearch;
+            onSearch(inputValue);
           }
         }}
       />

--- a/app/components/list/applicationFields.tsx
+++ b/app/components/list/applicationFields.tsx
@@ -11,7 +11,7 @@ const ApplicationFields = ({
   specialAnswerList,
 }: ApplicationFieldsProps) => {
   return (
-    <>
+    <div className="flex flex-col gap-[30px] md:gap-10">
       {/* 뱃지 항목에 대한 답변 */}
       <ul className="flex flex-col md:gap-10 gap-[30px]">
         {Object.entries({ name: name, ...specialAnswerList })
@@ -46,7 +46,7 @@ const ApplicationFields = ({
       </ul>
 
       {/* 포폴 관련 데이터 추가 필요 */}
-    </>
+    </div>
   );
 };
 

--- a/app/components/list/applicationFields.tsx
+++ b/app/components/list/applicationFields.tsx
@@ -1,0 +1,53 @@
+import { BADGE_TITLE_MAP } from "@/constants/application";
+import { ApplyDetailRes } from "@/types/application";
+
+interface ApplicationFieldsProps extends Omit<ApplyDetailRes, "applyData"> {
+  name: string;
+}
+
+const ApplicationFields = ({
+  name,
+  applyAnswerDataList,
+  specialAnswerList,
+}: ApplicationFieldsProps) => {
+  return (
+    <>
+      {/* 뱃지 항목에 대한 답변 */}
+      <ul className="flex flex-col md:gap-10 gap-[30px]">
+        {Object.entries({ name: name, ...specialAnswerList })
+          .filter(([_, value]) => value != null)
+          .map(([name, value]) => (
+            <li key={name} className="flex flex-col md:gap-3 gap-2">
+              <p className="md:text-h3 text-mobile_h3">
+                {name === "name" ? "이름" : BADGE_TITLE_MAP[name]}
+              </p>
+              <p className="md:text-body1_m text-mobile_body1_r text-subtext1">
+                {value}
+              </p>
+            </li>
+          ))}
+      </ul>
+
+      {/* 추가 선택 항목에 대한 답변 */}
+      <ul className="flex flex-col md:gap-10 gap-[30px]">
+        {applyAnswerDataList.map((answer) => (
+          <li
+            key={answer.applyQuestionData.id}
+            className="flex flex-col md:gap-[18px] gap-[14px]"
+          >
+            <p className="md:text-h3 text-mobile_h3">
+              {answer.applyQuestionData.body}
+            </p>
+            <p className="bg-searchbar text-subtext1 rounded-12 md:text-body1_r text-mobile_body1_r md:py-[14px] md:px-[22px] py-3 px-4">
+              {answer.body}
+            </p>
+          </li>
+        ))}
+      </ul>
+
+      {/* 포폴 관련 데이터 추가 필요 */}
+    </>
+  );
+};
+
+export default ApplicationFields;

--- a/app/components/list/applicationFields.tsx
+++ b/app/components/list/applicationFields.tsx
@@ -1,5 +1,8 @@
 import { BADGE_TITLE_MAP } from "@/constants/application";
 import { ApplyDetailRes } from "@/types/application";
+import PDFDownloadBtn from "../button/pdfDownloadBtn";
+import FileBadge from "../badge/fileBadge";
+import Link from "next/link";
 
 interface ApplicationFieldsProps extends Omit<ApplyDetailRes, "applyData"> {
   name: string;
@@ -9,6 +12,8 @@ const ApplicationFields = ({
   name,
   applyAnswerDataList,
   specialAnswerList,
+  fileUri,
+  portfolioUrl,
 }: ApplicationFieldsProps) => {
   return (
     <div className="flex flex-col gap-[30px] md:gap-10">
@@ -45,7 +50,30 @@ const ApplicationFields = ({
         ))}
       </ul>
 
-      {/* 포폴 관련 데이터 추가 필요 */}
+      {/* 포트폴리오(fileUri / portfolioUrl) */}
+      <div className="flex flex-col md:gap-[18px] gap-[14px]">
+        <p className="md:text-h3 text-mobile_h3">포트폴리오</p>
+        <div className="flex flex-col gap-3">
+          {fileUri && (
+            <div className="flex gap-2 ">
+              <FileBadge fileName={fileUri} />
+              <PDFDownloadBtn
+                file={fileUri}
+                fileName={`${fileUri}_Portfolio`}
+              />
+            </div>
+          )}
+          {portfolioUrl && (
+            <Link
+              href={portfolioUrl}
+              target="_blank"
+              className="bg-searchbar text-subtext1 rounded-12 md:text-body1_r text-mobile_body1_r md:py-[14px] md:px-[22px] py-3 px-4 underline"
+            >
+              {portfolioUrl}
+            </Link>
+          )}
+        </div>
+      </div>
     </div>
   );
 };

--- a/app/components/modal/club/applicationFormViewModal.tsx
+++ b/app/components/modal/club/applicationFormViewModal.tsx
@@ -1,7 +1,5 @@
-import React, { useEffect, useRef, useState } from "react";
+import React, { useEffect, useRef } from "react";
 import Image from "next/image";
-import SingleSelectOptions from "@/components/pulldown/singleSelectOptions";
-import vector from "@/images/icon/sub_pull_down.svg";
 import ResultBadge from "@/components/badge/resultBadge";
 import close from "@/images/icon/close.svg";
 import FileBadge from "@/components/badge/fileBadge";
@@ -13,24 +11,26 @@ import defaultImg from "@/images/icon/defaultAriari.svg";
 import { APPLY_STATUS_MAP } from "@/constants/application";
 import ApplicationFields from "@/components/list/applicationFields";
 import { getProfileImage } from "@/utils/profileImage";
+import UpdateApplyStatusOptions from "@/components/dropdown/updateApplyStatusOptions";
 
 export interface ApplicationFormViewModalProps {
   applyId: string;
   onClose: () => void;
+  isOptionsOpen: boolean;
+  setIsOptionsOpen: (isOpen: boolean) => void;
+  setSelectedOption: (option: string) => void;
+  setIsModalOpen: (isOpen: boolean) => void;
 }
 
 const ApplicationFormViewModal = ({
   applyId,
   onClose,
-  data,
-  portfolio,
-  portfolioData,
-  fields,
-}: ApplicationFormViewModalProps) => {
+  isOptionsOpen,
+  setIsOptionsOpen,
+  setSelectedOption,
+  setIsModalOpen,
+}: ApplicationFromViewModalProps) => {
   const optionsRef = useRef<HTMLDivElement | null>(null);
-
-  const [isOptionsOpen, setIsOptionsOpen] = useState<boolean>(false);
-  const [selectedStatus, setSelectedStatus] = useState<string>("");
 
   const { applyDetail, isError, isLoading } = useApplyDetailQuery(applyId);
   const {
@@ -42,7 +42,7 @@ const ApplicationFormViewModal = ({
   } = applyDetail ?? {};
 
   const handleMenuClick = (label: string) => {
-    setSelectedStatus(label);
+    setSelectedOption(label);
   };
 
   const handleClose = () => {
@@ -97,26 +97,14 @@ const ApplicationFormViewModal = ({
           </span>
         </div>
         <div className="flex gap-2">
-          <div
-            className="relative flex items-center gap-2 cursor-pointer"
-            onClick={() => setIsOptionsOpen(!isOptionsOpen)}
-          >
-            <p className="text-subtext2 text-body1_m">지원상태 변경</p>
-            <Image alt={"버튼"} src={vector} width={28} height={28} />
-            {isOptionsOpen && (
-              <div
-                ref={optionsRef}
-                className="absolute top-full mt-2 z-50 left-12"
-              >
-                <SingleSelectOptions
-                  selectedOption={selectedStatus}
-                  optionData={[...STATUS_OPTIONS]}
-                  size="medium"
-                  handleMenuClick={handleMenuClick}
-                />
-              </div>
-            )}
-          </div>
+          <UpdateApplyStatusOptions
+            checkedApplications={[applyId]}
+            isOptionsOpen={isOptionsOpen}
+            setIsOptionsOpen={setIsOptionsOpen}
+            setSelectedStatus={setSelectedOption}
+            setIsModalOpen={setIsModalOpen}
+            optionsRef={optionsRef}
+          />
           <ResultBadge status={APPLY_STATUS_MAP[applyData.applyStatusType]} />
         </div>
       </div>

--- a/app/components/modal/club/applicationFormViewModal.tsx
+++ b/app/components/modal/club/applicationFormViewModal.tsx
@@ -2,10 +2,6 @@ import React, { useEffect } from "react";
 import Image from "next/image";
 import ResultBadge from "@/components/badge/resultBadge";
 import close from "@/images/icon/close.svg";
-import FileBadge from "@/components/badge/fileBadge";
-import CustomInput from "@/components/input/customInput";
-import PDFDownloadBtn from "@/components/button/pdfDownloadBtn";
-import { STATUS_OPTIONS } from "@/(club)/club/management/recruitment/applicationStatus/page";
 import { useApplyDetailQuery } from "@/hooks/apply/useApplicationQuery";
 import defaultImg from "@/images/icon/defaultAriari.svg";
 import { APPLY_STATUS_MAP } from "@/constants/application";
@@ -104,32 +100,9 @@ const ApplicationFormViewModal = ({
             name={applyData.name}
             specialAnswerList={specialAnswerList!}
             applyAnswerDataList={applyAnswerDataList || []}
+            fileUri={fileUri}
+            portfolioUrl={portfolioUrl}
           />
-          {/* {portfolio && portfolioData && (
-            <>
-              <div className="flex flex-col gap-2.5 mt-10">
-                <h3 className="text-text1 text-h3">포트폴리오</h3>
-                <p className="text-subtext2 text-body1_r">
-                  포트폴리오 수집 목적 문구
-                </p>
-              </div>
-              <div className="flex gap-2 mt-5 mb-3 ">
-                {portfolioData.portfolioFile && (
-                  <FileBadge fileName={portfolioData.portfolioFile} />
-                )}
-                <PDFDownloadBtn
-                  file={portfolioData.portfolioFile}
-                  fileName={`${data.name}_Portfolio`}
-                />
-              </div>
-              <CustomInput
-                disable={true}
-                value={portfolioData.portfolioText}
-                placeholder={""}
-                onChange={() => {}}
-              />
-            </>
-          )} */}
         </div>
       </div>
     </div>

--- a/app/components/modal/club/applicationFormViewModal.tsx
+++ b/app/components/modal/club/applicationFormViewModal.tsx
@@ -7,8 +7,10 @@ import close from "@/images/icon/close.svg";
 import FileBadge from "@/components/badge/fileBadge";
 import CustomInput from "@/components/input/customInput";
 import PDFDownloadBtn from "@/components/button/pdfDownloadBtn";
+import { STATUS_OPTIONS } from "@/(club)/club/management/recruitment/applicationStatus/page";
 
 export interface ApplicationFormViewModalProps {
+  applyId: string;
   onClose: () => void;
   portfolio: boolean;
   portfolioData?: {
@@ -25,6 +27,7 @@ export interface ApplicationFormViewModalProps {
 }
 
 const ApplicationFormViewModal = ({
+  applyId,
   onClose,
   data,
   portfolio,
@@ -92,12 +95,7 @@ const ApplicationFormViewModal = ({
               >
                 <SingleSelectOptions
                   selectedOption={selectedStatus}
-                  optionData={[
-                    { id: 1, label: "합격" },
-                    { id: 2, label: "불합격" },
-                    { id: 3, label: "대기중" },
-                    { id: 4, label: "면접중" },
-                  ]}
+                  optionData={[...STATUS_OPTIONS]}
                   size="medium"
                   handleMenuClick={handleMenuClick}
                 />
@@ -112,6 +110,7 @@ const ApplicationFormViewModal = ({
       <div className="bg-white w-[900px] max-h-[75vh] rounded-2xl shadow-modal flex flex-col p-6">
         <div className="custom-scrollbar overflow-y-auto">
           <div className="flex flex-col gap-10 ">
+            {/* 지원서 항목 리스트 */}
             {fields.map((field, index) => (
               <div key={index} className="flex flex-col gap-3">
                 <h3 className="text-text1 text-h3">{field.label}</h3>

--- a/app/components/modal/club/applicationFormViewModal.tsx
+++ b/app/components/modal/club/applicationFormViewModal.tsx
@@ -8,21 +8,14 @@ import FileBadge from "@/components/badge/fileBadge";
 import CustomInput from "@/components/input/customInput";
 import PDFDownloadBtn from "@/components/button/pdfDownloadBtn";
 import { STATUS_OPTIONS } from "@/(club)/club/management/recruitment/applicationStatus/page";
+import { useApplyDetailQuery } from "@/hooks/apply/useApplicationQuery";
+import defaultImg from "@/images/icon/defaultAriari.svg";
+import { APPLY_STATUS_MAP } from "@/constants/application";
+import ApplicationFields from "@/components/list/applicationFields";
 
 export interface ApplicationFormViewModalProps {
   applyId: string;
   onClose: () => void;
-  portfolio: boolean;
-  portfolioData?: {
-    portfolioPurpose: string;
-    portfolioText: string;
-    portfolioFile: string;
-  };
-  data: {
-    name: string;
-    image: string;
-    nickname: string;
-  };
 }
 
 const ApplicationFormViewModal = ({
@@ -37,6 +30,15 @@ const ApplicationFormViewModal = ({
 
   const [isOptionsOpen, setIsOptionsOpen] = useState<boolean>(false);
   const [selectedStatus, setSelectedStatus] = useState<string>("");
+
+  const { applyDetail, isError, isLoading } = useApplyDetailQuery(applyId);
+  const {
+    applyData,
+    applyAnswerDataList,
+    specialAnswerList,
+    fileUri,
+    portfolioUrl,
+  } = applyDetail ?? {};
 
   const handleMenuClick = (label: string) => {
     setSelectedStatus(label);
@@ -54,6 +56,10 @@ const ApplicationFormViewModal = ({
       document.body.style.overflow = "auto";
     };
   }, []);
+
+  if (!applyData) {
+    return null;
+  }
 
   return (
     <div
@@ -76,9 +82,16 @@ const ApplicationFormViewModal = ({
       items-center justify-between py-[14px] px-6"
       >
         <div className="flex gap-3 items-center">
-          <Image src={data.image} alt={"프로필"} />
-          <h1 className="text-text1 text-h4_sb">{`(${data.name})의 지원서`}</h1>
-          <span className="text-subtext2 text-body3_m">{data.nickname}</span>
+          <Image
+            src={applyData?.memberData?.profileType || defaultImg}
+            alt={"프로필"}
+            width={32}
+            height={32}
+          />
+          <h1 className="text-text1 text-h4_sb">{`(${applyData?.name})의 지원서`}</h1>
+          <span className="text-subtext2 text-body3_m">
+            {applyData?.memberData?.nickname}
+          </span>
         </div>
         <div className="flex gap-2">
           <div
@@ -101,23 +114,20 @@ const ApplicationFormViewModal = ({
               </div>
             )}
           </div>
-          <ResultBadge status={"합격"} />
+          <ResultBadge status={APPLY_STATUS_MAP[applyData.applyStatusType]} />
         </div>
       </div>
 
       {/* Content 영역 */}
       <div className="bg-white w-[900px] max-h-[75vh] rounded-2xl shadow-modal flex flex-col p-6">
         <div className="custom-scrollbar overflow-y-auto">
-          <div className="flex flex-col gap-10 ">
-            {/* 지원서 항목 리스트 */}
-            {fields.map((field, index) => (
-              <div key={index} className="flex flex-col gap-3">
-                <h3 className="text-text1 text-h3">{field.label}</h3>
-                <p className="text-subtext1 text-body1_m">{field.value}</p>
-              </div>
-            ))}
-          </div>
-          {portfolio && portfolioData && (
+          {/* 지원서 항목 리스트 */}
+          <ApplicationFields
+            name={applyData.name}
+            specialAnswerList={specialAnswerList!}
+            applyAnswerDataList={applyAnswerDataList || []}
+          />
+          {/* {portfolio && portfolioData && (
             <>
               <div className="flex flex-col gap-2.5 mt-10">
                 <h3 className="text-text1 text-h3">포트폴리오</h3>
@@ -141,7 +151,7 @@ const ApplicationFormViewModal = ({
                 onChange={() => {}}
               />
             </>
-          )}
+          )} */}
         </div>
       </div>
     </div>

--- a/app/components/modal/club/applicationFormViewModal.tsx
+++ b/app/components/modal/club/applicationFormViewModal.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useRef } from "react";
+import React, { useEffect } from "react";
 import Image from "next/image";
 import ResultBadge from "@/components/badge/resultBadge";
 import close from "@/images/icon/close.svg";
@@ -16,8 +16,6 @@ import UpdateApplyStatusOptions from "@/components/dropdown/updateApplyStatusOpt
 export interface ApplicationFormViewModalProps {
   applyId: string;
   onClose: () => void;
-  isOptionsOpen: boolean;
-  setIsOptionsOpen: (isOpen: boolean) => void;
   setSelectedOption: (option: string) => void;
   setIsModalOpen: (isOpen: boolean) => void;
 }
@@ -25,13 +23,9 @@ export interface ApplicationFormViewModalProps {
 const ApplicationFormViewModal = ({
   applyId,
   onClose,
-  isOptionsOpen,
-  setIsOptionsOpen,
   setSelectedOption,
   setIsModalOpen,
 }: ApplicationFromViewModalProps) => {
-  const optionsRef = useRef<HTMLDivElement | null>(null);
-
   const { applyDetail, isError, isLoading } = useApplyDetailQuery(applyId);
   const {
     applyData,
@@ -40,10 +34,6 @@ const ApplicationFormViewModal = ({
     fileUri,
     portfolioUrl,
   } = applyDetail ?? {};
-
-  const handleMenuClick = (label: string) => {
-    setSelectedOption(label);
-  };
 
   const handleClose = () => {
     onClose();
@@ -99,11 +89,8 @@ const ApplicationFormViewModal = ({
         <div className="flex gap-2">
           <UpdateApplyStatusOptions
             checkedApplications={[applyId]}
-            isOptionsOpen={isOptionsOpen}
-            setIsOptionsOpen={setIsOptionsOpen}
             setSelectedStatus={setSelectedOption}
             setIsModalOpen={setIsModalOpen}
-            optionsRef={optionsRef}
           />
           <ResultBadge status={APPLY_STATUS_MAP[applyData.applyStatusType]} />
         </div>

--- a/app/components/modal/club/applicationFormViewModal.tsx
+++ b/app/components/modal/club/applicationFormViewModal.tsx
@@ -23,7 +23,6 @@ export interface ApplicationFormViewModalProps {
     image: string;
     nickname: string;
   };
-  fields: { label: string; value: string }[];
 }
 
 const ApplicationFormViewModal = ({

--- a/app/components/modal/club/applicationFormViewModal.tsx
+++ b/app/components/modal/club/applicationFormViewModal.tsx
@@ -21,7 +21,7 @@ const ApplicationFormViewModal = ({
   onClose,
   setSelectedOption,
   setIsModalOpen,
-}: ApplicationFromViewModalProps) => {
+}: ApplicationFormViewModalProps) => {
   const { applyDetail, isError, isLoading } = useApplyDetailQuery(applyId);
   const {
     applyData,
@@ -71,7 +71,7 @@ const ApplicationFormViewModal = ({
         <div className="flex gap-3 items-center">
           <Image
             src={
-              getProfileImage(applyData?.memberData?.profileType) || defaultImg
+              getProfileImage(applyData.memberData.profileType!) || defaultImg
             }
             alt={"프로필"}
             width={32}

--- a/app/components/modal/club/applicationFormViewModal.tsx
+++ b/app/components/modal/club/applicationFormViewModal.tsx
@@ -12,6 +12,7 @@ import { useApplyDetailQuery } from "@/hooks/apply/useApplicationQuery";
 import defaultImg from "@/images/icon/defaultAriari.svg";
 import { APPLY_STATUS_MAP } from "@/constants/application";
 import ApplicationFields from "@/components/list/applicationFields";
+import { getProfileImage } from "@/utils/profileImage";
 
 export interface ApplicationFormViewModalProps {
   applyId: string;
@@ -83,7 +84,9 @@ const ApplicationFormViewModal = ({
       >
         <div className="flex gap-3 items-center">
           <Image
-            src={applyData?.memberData?.profileType || defaultImg}
+            src={
+              getProfileImage(applyData?.memberData?.profileType) || defaultImg
+            }
             alt={"프로필"}
             width={32}
             height={32}

--- a/app/components/modal/club/interviewNoticeModal.tsx
+++ b/app/components/modal/club/interviewNoticeModal.tsx
@@ -4,10 +4,17 @@ import close from "@/images/icon/close.svg";
 import help from "@/images/icon/help.svg";
 import Alert from "@/components/alert/alert";
 import SmallBtn from "@/components/button/basicBtn/smallBtn";
-import { InterviewNoticeProps } from "@/types/components/review";
 import Contour from "@/components/bar/contour";
 
-const InterviewNoticeModal = ({ onClose, onSubmit }: InterviewNoticeProps) => {
+export interface InterviewNoticeModalProps {
+  onClose: () => void;
+  onSubmit: (message: string) => void;
+}
+
+const InterviewNoticeModal = ({
+  onClose,
+  onSubmit,
+}: InterviewNoticeModalProps) => {
   const [details, setDetails] = useState<string>("");
   const [alertMessage, setAlertMessage] = useState<string | null>(null);
 
@@ -21,7 +28,7 @@ const InterviewNoticeModal = ({ onClose, onSubmit }: InterviewNoticeProps) => {
 
   const handleSubmit = () => {
     if (validateForm()) {
-      onSubmit();
+      onSubmit(details);
       onClose();
     }
   };

--- a/app/components/modal/club/mobileApplicationFormViewModal.tsx
+++ b/app/components/modal/club/mobileApplicationFormViewModal.tsx
@@ -61,7 +61,7 @@ const MobileApplicationFormViewModal = ({
             className="md:hidden cursor-pointer"
           />
           <h1 className="text-text1 text-mobile_h1_contents_title md:text-h1_contents_title">
-            관심 동아리
+            ({applyData.name})님의 지원서
           </h1>
         </div>
         <div className="flex justify-between mt-6 mb-5">

--- a/app/components/modal/club/mobileApplicationFormViewModal.tsx
+++ b/app/components/modal/club/mobileApplicationFormViewModal.tsx
@@ -1,7 +1,6 @@
-import React, { useState } from "react";
+import React, { useRef } from "react";
 import Image from "next/image";
 import vector from "@/images/icon/backVector.svg";
-import pull_down from "@/images/icon/sub_pull_down.svg";
 import { ApplicationFromViewModalProps } from "./applicationFormViewModal";
 import Contour from "@/components/bar/contour";
 import FileBadge from "@/components/badge/fileBadge";
@@ -11,17 +10,21 @@ import { useApplyDetailQuery } from "@/hooks/apply/useApplicationQuery";
 import defaultImg from "@/images/icon/defaultAriari.svg";
 import ApplicationFields from "@/components/list/applicationFields";
 import { getProfileImage } from "@/utils/profileImage";
+import UpdateApplyStatusOptions from "@/components/dropdown/updateApplyStatusOptions";
 
 interface MobileApplicationFormViewModal extends ApplicationFromViewModalProps {
-  onOpenStatusOptions: () => void;
+  setIsOptionsOpen: (isOpen: boolean) => void;
 }
 
 const MobileApplicationFormViewModal = ({
   applyId,
-  onOpenStatusOptions,
+  setIsOptionsOpen,
+  isOptionsOpen,
+  setIsModalOpen,
+  setSelectedOption,
   onClose,
 }: MobileApplicationFormViewModal) => {
-  const [selectedStatus, setSelectedStatus] = useState<string>("");
+  const optionsRef = useRef<HTMLDivElement | null>(null);
 
   const { applyDetail, isError, isLoading } = useApplyDetailQuery(applyId);
   const {
@@ -37,7 +40,7 @@ const MobileApplicationFormViewModal = ({
   };
 
   const handleMenuClick = (label: string) => {
-    setSelectedStatus(label);
+    // setSelectedStatus(label);
   };
 
   if (!applyData) {
@@ -82,13 +85,14 @@ const MobileApplicationFormViewModal = ({
               </p>
             </div>
           </div>
-          <div
-            className="relative flex items-center gap-1 cursor-pointer"
-            onClick={onOpenStatusOptions}
-          >
-            <p className="text-subtext2 text-mobile_body2_m">지원상태 변경</p>
-            <Image alt={"버튼"} src={pull_down} width={20} height={20} />
-          </div>
+          <UpdateApplyStatusOptions
+            checkedApplications={[applyId]}
+            isOptionsOpen={isOptionsOpen}
+            setIsModalOpen={setIsModalOpen}
+            setIsOptionsOpen={setIsOptionsOpen}
+            setSelectedStatus={setSelectedOption}
+            optionsRef={optionsRef}
+          />
         </div>
         <Contour className="mb-6" />
       </div>

--- a/app/components/modal/club/mobileApplicationFormViewModal.tsx
+++ b/app/components/modal/club/mobileApplicationFormViewModal.tsx
@@ -1,9 +1,8 @@
-import React, { useRef, useState } from "react";
+import React, { useState } from "react";
 import Image from "next/image";
 import vector from "@/images/icon/backVector.svg";
 import pull_down from "@/images/icon/sub_pull_down.svg";
-import { ApplicationFormViewModalProps } from "./applicationFormViewModal";
-import SingleSelectOptions from "@/components/pulldown/singleSelectOptions";
+import { ApplicationFromViewModalProps } from "./applicationFormViewModal";
 import Contour from "@/components/bar/contour";
 import FileBadge from "@/components/badge/fileBadge";
 import PDFDownloadBtn from "@/components/button/pdfDownloadBtn";
@@ -11,19 +10,17 @@ import CustomInput from "@/components/input/customInput";
 import { useApplyDetailQuery } from "@/hooks/apply/useApplicationQuery";
 import defaultImg from "@/images/icon/defaultAriari.svg";
 import ApplicationFields from "@/components/list/applicationFields";
-import { STATUS_OPTIONS } from "@/(club)/club/management/recruitment/applicationStatus/page";
+import { getProfileImage } from "@/utils/profileImage";
+
+interface MobileApplicationFormViewModal extends ApplicationFromViewModalProps {
+  onOpenStatusOptions: () => void;
+}
 
 const MobileApplicationFormViewModal = ({
   applyId,
+  onOpenStatusOptions,
   onClose,
-  data,
-  portfolio,
-  portfolioData,
-  fields,
-}: ApplicationFormViewModalProps) => {
-  const optionsRef = useRef<HTMLDivElement | null>(null);
-
-  const [isOptionsOpen, setIsOptionsOpen] = useState<boolean>(false);
+}: MobileApplicationFormViewModal) => {
   const [selectedStatus, setSelectedStatus] = useState<string>("");
 
   const { applyDetail, isError, isLoading } = useApplyDetailQuery(applyId);
@@ -70,7 +67,10 @@ const MobileApplicationFormViewModal = ({
         <div className="flex justify-between mt-6 mb-5">
           <div className="flex gap-2.5">
             <Image
-              src={applyData?.memberData?.profileType || defaultImg}
+              src={
+                getProfileImage(applyData?.memberData?.profileType) ||
+                defaultImg
+              }
               alt={"프로필"}
               width={48}
               height={48}
@@ -84,23 +84,10 @@ const MobileApplicationFormViewModal = ({
           </div>
           <div
             className="relative flex items-center gap-1 cursor-pointer"
-            onClick={() => setIsOptionsOpen(!isOptionsOpen)}
+            onClick={onOpenStatusOptions}
           >
             <p className="text-subtext2 text-mobile_body2_m">지원상태 변경</p>
             <Image alt={"버튼"} src={pull_down} width={20} height={20} />
-            {isOptionsOpen && (
-              <div
-                ref={optionsRef}
-                className="absolute top-full mt-2 z-50 left-12"
-              >
-                <SingleSelectOptions
-                  selectedOption={selectedStatus}
-                  optionData={[...STATUS_OPTIONS]}
-                  size="small"
-                  handleMenuClick={handleMenuClick}
-                />
-              </div>
-            )}
           </div>
         </div>
         <Contour className="mb-6" />

--- a/app/components/modal/club/mobileApplicationFormViewModal.tsx
+++ b/app/components/modal/club/mobileApplicationFormViewModal.tsx
@@ -8,8 +8,13 @@ import Contour from "@/components/bar/contour";
 import FileBadge from "@/components/badge/fileBadge";
 import PDFDownloadBtn from "@/components/button/pdfDownloadBtn";
 import CustomInput from "@/components/input/customInput";
+import { useApplyDetailQuery } from "@/hooks/apply/useApplicationQuery";
+import defaultImg from "@/images/icon/defaultAriari.svg";
+import ApplicationFields from "@/components/list/applicationFields";
+import { STATUS_OPTIONS } from "@/(club)/club/management/recruitment/applicationStatus/page";
 
 const MobileApplicationFormViewModal = ({
+  applyId,
   onClose,
   data,
   portfolio,
@@ -21,6 +26,15 @@ const MobileApplicationFormViewModal = ({
   const [isOptionsOpen, setIsOptionsOpen] = useState<boolean>(false);
   const [selectedStatus, setSelectedStatus] = useState<string>("");
 
+  const { applyDetail, isError, isLoading } = useApplyDetailQuery(applyId);
+  const {
+    applyData,
+    applyAnswerDataList,
+    specialAnswerList,
+    fileUri,
+    portfolioUrl,
+  } = applyDetail ?? {};
+
   const handleClose = () => {
     onClose();
   };
@@ -28,6 +42,10 @@ const MobileApplicationFormViewModal = ({
   const handleMenuClick = (label: string) => {
     setSelectedStatus(label);
   };
+
+  if (!applyData) {
+    return null;
+  }
 
   return (
     <div
@@ -51,11 +69,16 @@ const MobileApplicationFormViewModal = ({
         </div>
         <div className="flex justify-between mt-6 mb-5">
           <div className="flex gap-2.5">
-            <Image src={data.image} alt={"프로필"} width={48} height={48} />
+            <Image
+              src={applyData?.memberData?.profileType || defaultImg}
+              alt={"프로필"}
+              width={48}
+              height={48}
+            />
             <div className="flex flex-col gap-0.5">
-              <h1 className="text-text1 text-h4_sb">{data.name}</h1>
+              <h1 className="text-text1 text-h4_sb">{applyData?.name}</h1>
               <p className="text-subtext2 text-mobile_body2_r">
-                {data.nickname}
+                {applyData?.memberData.nickname}
               </p>
             </div>
           </div>
@@ -72,12 +95,7 @@ const MobileApplicationFormViewModal = ({
               >
                 <SingleSelectOptions
                   selectedOption={selectedStatus}
-                  optionData={[
-                    { id: 1, label: "합격" },
-                    { id: 2, label: "불합격" },
-                    { id: 3, label: "대기중" },
-                    { id: 4, label: "면접중" },
-                  ]}
+                  optionData={[...STATUS_OPTIONS]}
                   size="small"
                   handleMenuClick={handleMenuClick}
                 />
@@ -90,15 +108,13 @@ const MobileApplicationFormViewModal = ({
 
       {/* 스크롤 가능한 콘텐츠 영역 */}
       <div className="flex-1 overflow-y-auto">
-        <div className="flex flex-col gap-[30px]">
-          {fields.map((field, index) => (
-            <div key={index} className="flex flex-col gap-2">
-              <h3 className="text-text1 text-mobile_h3">{field.label}</h3>
-              <p className="text-subtext1 text-mobile_body1_r">{field.value}</p>
-            </div>
-          ))}
-        </div>
-        {portfolio && portfolioData && (
+        {/* 지원서 항목 리스트 */}
+        <ApplicationFields
+          name={applyData.name}
+          specialAnswerList={specialAnswerList!}
+          applyAnswerDataList={applyAnswerDataList || []}
+        />
+        {/* {portfolio && portfolioData && (
           <>
             <div className="flex flex-col gap-2.5 mt-[30px]">
               <h3 className="text-text1 text-mobile_h3">포트폴리오</h3>
@@ -123,7 +139,7 @@ const MobileApplicationFormViewModal = ({
               />
             </div>
           </>
-        )}
+        )} */}
       </div>
     </div>
   );

--- a/app/components/modal/club/mobileApplicationFormViewModal.tsx
+++ b/app/components/modal/club/mobileApplicationFormViewModal.tsx
@@ -12,18 +12,12 @@ import ApplicationFields from "@/components/list/applicationFields";
 import { getProfileImage } from "@/utils/profileImage";
 import UpdateApplyStatusOptions from "@/components/dropdown/updateApplyStatusOptions";
 
-interface MobileApplicationFormViewModal extends ApplicationFromViewModalProps {
-  setIsOptionsOpen: (isOpen: boolean) => void;
-}
-
 const MobileApplicationFormViewModal = ({
   applyId,
-  setIsOptionsOpen,
-  isOptionsOpen,
   setIsModalOpen,
   setSelectedOption,
   onClose,
-}: MobileApplicationFormViewModal) => {
+}: ApplicationFromViewModalProps) => {
   const optionsRef = useRef<HTMLDivElement | null>(null);
 
   const { applyDetail, isError, isLoading } = useApplyDetailQuery(applyId);
@@ -37,10 +31,6 @@ const MobileApplicationFormViewModal = ({
 
   const handleClose = () => {
     onClose();
-  };
-
-  const handleMenuClick = (label: string) => {
-    // setSelectedStatus(label);
   };
 
   if (!applyData) {
@@ -87,11 +77,8 @@ const MobileApplicationFormViewModal = ({
           </div>
           <UpdateApplyStatusOptions
             checkedApplications={[applyId]}
-            isOptionsOpen={isOptionsOpen}
             setIsModalOpen={setIsModalOpen}
-            setIsOptionsOpen={setIsOptionsOpen}
             setSelectedStatus={setSelectedOption}
-            optionsRef={optionsRef}
           />
         </div>
         <Contour className="mb-6" />

--- a/app/components/modal/club/mobileApplicationFormViewModal.tsx
+++ b/app/components/modal/club/mobileApplicationFormViewModal.tsx
@@ -3,9 +3,6 @@ import Image from "next/image";
 import vector from "@/images/icon/backVector.svg";
 import { ApplicationFromViewModalProps } from "./applicationFormViewModal";
 import Contour from "@/components/bar/contour";
-import FileBadge from "@/components/badge/fileBadge";
-import PDFDownloadBtn from "@/components/button/pdfDownloadBtn";
-import CustomInput from "@/components/input/customInput";
 import { useApplyDetailQuery } from "@/hooks/apply/useApplicationQuery";
 import defaultImg from "@/images/icon/defaultAriari.svg";
 import ApplicationFields from "@/components/list/applicationFields";
@@ -91,33 +88,9 @@ const MobileApplicationFormViewModal = ({
           name={applyData.name}
           specialAnswerList={specialAnswerList!}
           applyAnswerDataList={applyAnswerDataList || []}
+          fileUri={fileUri}
+          portfolioUrl={portfolioUrl}
         />
-        {/* {portfolio && portfolioData && (
-          <>
-            <div className="flex flex-col gap-2.5 mt-[30px]">
-              <h3 className="text-text1 text-mobile_h3">포트폴리오</h3>
-              <p className="text-subtext2 text-mobile_body3_r">
-                포트폴리오 수집 목적 문구
-              </p>
-            </div>
-            <CustomInput
-              disable={true}
-              value={portfolioData.portfolioText}
-              placeholder={""}
-              onChange={() => {}}
-              className="mt-[14px]"
-            />
-            <div className="flex gap-2 mt-[14px] mb-20">
-              {portfolioData.portfolioFile && (
-                <FileBadge fileName={portfolioData.portfolioFile} />
-              )}
-              <PDFDownloadBtn
-                file={portfolioData.portfolioFile}
-                fileName={`${data.name}_Portfolio`}
-              />
-            </div>
-          </>
-        )} */}
       </div>
     </div>
   );

--- a/app/constants/application.ts
+++ b/app/constants/application.ts
@@ -1,9 +1,6 @@
-import { ApplyStatusType } from "@/types/application";
+import { ApplyStatusType, AppyStatusText } from "@/types/application";
 
-export const APPLY_STATUS: Record<
-  ApplyStatusType,
-  "대기중" | "면접중" | "합격" | "불합격"
-> = {
+export const APPLY_STATUS: Record<ApplyStatusType, AppyStatusText> = {
   PENDENCY: "대기중",
   INTERVIEW: "면접중",
   APPROVE: "합격",

--- a/app/constants/application.ts
+++ b/app/constants/application.ts
@@ -8,6 +8,14 @@ export const APPLY_STATUS_MAP: Record<ApplyStatusType, AppyStatusText> = {
   REFUSAL: "불합격",
 };
 
+export type StatusValue = "refuse" | "interview" | "approve";
+
+export const APPLY_STATUS_VALUE_MAP: Record<string, StatusValue> = {
+  면접중: "interview",
+  합격: "approve",
+  불합격: "refuse",
+} as const;
+
 export const BADGE_TITLE_MAP = BADGE_ITEMS.reduce((acc, item) => {
   acc[item.key] = item.name;
   return acc;

--- a/app/constants/application.ts
+++ b/app/constants/application.ts
@@ -1,0 +1,11 @@
+import { ApplyStatusType } from "@/types/application";
+
+export const APPLY_STATUS: Record<
+  ApplyStatusType,
+  "대기중" | "면접중" | "합격" | "불합격"
+> = {
+  PENDENCY: "대기중",
+  INTERVIEW: "면접중",
+  APPROVE: "합격",
+  REFUSAL: "불합격",
+};

--- a/app/constants/application.ts
+++ b/app/constants/application.ts
@@ -1,8 +1,14 @@
+import { BADGE_ITEMS } from "@/data/club";
 import { ApplyStatusType, AppyStatusText } from "@/types/application";
 
-export const APPLY_STATUS: Record<ApplyStatusType, AppyStatusText> = {
+export const APPLY_STATUS_MAP: Record<ApplyStatusType, AppyStatusText> = {
   PENDENCY: "대기중",
   INTERVIEW: "면접중",
   APPROVE: "합격",
   REFUSAL: "불합격",
 };
+
+export const BADGE_TITLE_MAP = BADGE_ITEMS.reduce((acc, item) => {
+  acc[item.key] = item.name;
+  return acc;
+}, {} as Record<string, string>);

--- a/app/hooks/apply/useApplicationMutation.tsx
+++ b/app/hooks/apply/useApplicationMutation.tsx
@@ -1,0 +1,48 @@
+import {
+  updateApplicationStatus,
+  UpdateApplicationStatusParams,
+} from "@/api/apply/api";
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+import { useSearchParams } from "next/navigation";
+
+// 지원 현황 - 지원 상태 업데이트
+type UseUpdateStatusMutationProps = {
+  options?: {
+    onSuccess?: () => void;
+    onError?: (error: unknown) => void;
+  };
+};
+
+export const useUpdateStatusMutation = ({
+  options,
+}: UseUpdateStatusMutationProps = {}) => {
+  const queryClient = useQueryClient();
+  const params = useSearchParams();
+  const clubId = params.get("clubId") || "";
+
+  const mutation = useMutation({
+    mutationFn: ({ applications, type }: UpdateApplicationStatusParams) =>
+      updateApplicationStatus({ applications, type }),
+    onSuccess: (_, variables) => {
+      const { applications } = variables;
+      // 지원서 목록 데이터 갱신
+      queryClient.invalidateQueries({
+        queryKey: ["club", "applications", clubId],
+      });
+
+      // 지원서 상세 조회 데이터 갱신
+      applications.forEach((applyId) => {
+        queryClient.invalidateQueries({
+          queryKey: ["club", "application", applyId],
+        });
+      });
+
+      options?.onSuccess?.();
+    },
+    onError: (error) => {
+      options?.onError?.(error);
+    },
+  });
+
+  return { updateApplicationStatus: mutation };
+};

--- a/app/hooks/apply/useApplicationMutation.tsx
+++ b/app/hooks/apply/useApplicationMutation.tsx
@@ -21,8 +21,12 @@ export const useUpdateStatusMutation = ({
   const clubId = params.get("clubId") || "";
 
   const mutation = useMutation({
-    mutationFn: ({ applications, type }: UpdateApplicationStatusParams) =>
-      updateApplicationStatus({ applications, type }),
+    mutationFn: ({
+      applications,
+      type,
+      interviewMessage,
+    }: UpdateApplicationStatusParams) =>
+      updateApplicationStatus({ applications, type, interviewMessage }),
     onSuccess: (_, variables) => {
       const { applications } = variables;
       // 지원서 목록 데이터 갱신

--- a/app/hooks/apply/useApplicationQuery.tsx
+++ b/app/hooks/apply/useApplicationQuery.tsx
@@ -1,0 +1,55 @@
+import { getApplicationsList } from "@/api/apply/api";
+import { ApplicationListConditionReq, ApplyListRes } from "@/types/application";
+import { useInfiniteQuery, useQuery } from "@tanstack/react-query";
+import { AxiosError } from "axios";
+
+// 동아리 상세 지원 현황 리스트 조회
+export const useApplicationQuery = (
+  clubId: string,
+  condition: ApplicationListConditionReq
+) => {
+  const { data, fetchNextPage, hasNextPage, isFetchingNextPage, isError } =
+    useInfiniteQuery<ApplyListRes, AxiosError>({
+      queryKey: ["club", "applications", clubId, JSON.stringify(condition)],
+      queryFn: ({ pageParam = 0 }) =>
+        getApplicationsList(clubId, condition, pageParam as number),
+      initialPageParam: 0,
+      getNextPageParam: (lastPage, allPages) => {
+        const nextPage = allPages.length;
+        const totalPages = lastPage.pageInfo.totalPages;
+
+        // 마지막 페이지 판단 기준 - 전체 페이지 수, 현재 불러진 페이지 수
+        return totalPages > nextPage ? nextPage : undefined;
+      },
+    });
+
+  // 전체/대기중 탭에 표기되는 항목 개수
+  const { data: fixedTotalSize } = useQuery<
+    { totalAllSize: number; totalPendingSize: number },
+    AxiosError
+  >({
+    queryKey: ["club", "applications", clubId, "fixed-total-size"],
+    queryFn: async () => {
+      const [allApplyRes, pendingApplyRes] = await Promise.all([
+        getApplicationsList(clubId, { isPendent: false }, 0),
+        getApplicationsList(clubId, { isPendent: true }, 0),
+      ]);
+      return {
+        totalAllSize: allApplyRes.pageInfo.totalSize,
+        totalPendingSize: pendingApplyRes.pageInfo.totalSize,
+      };
+    },
+    staleTime: Infinity,
+  });
+
+  return {
+    allTabSize: fixedTotalSize?.totalAllSize ?? 0,
+    pendingTabSize: fixedTotalSize?.totalPendingSize ?? 0,
+    applicationsList: data?.pages.flatMap((page) => page.applyDataList) ?? [],
+    totalSize: data?.pages[0].pageInfo.totalSize ?? 0,
+    fetchNextPage,
+    hasNextPage,
+    isFetchingNextPage,
+    isError,
+  };
+};

--- a/app/hooks/apply/useApplicationQuery.tsx
+++ b/app/hooks/apply/useApplicationQuery.tsx
@@ -1,5 +1,9 @@
-import { getApplicationsList } from "@/api/apply/api";
-import { ApplicationListConditionReq, ApplyListRes } from "@/types/application";
+import { getApplicationDetail, getApplicationsList } from "@/api/apply/api";
+import {
+  ApplicationListConditionReq,
+  ApplyDetailRes,
+  ApplyListRes,
+} from "@/types/application";
 import { useInfiniteQuery, useQuery } from "@tanstack/react-query";
 import { AxiosError } from "axios";
 
@@ -50,6 +54,23 @@ export const useApplicationQuery = (
     fetchNextPage,
     hasNextPage,
     isFetchingNextPage,
+    isError,
+  };
+};
+
+// 동아리 상세 지원현황 - 지원서 상세 조회
+export const useApplyDetailQuery = (applyId: string) => {
+  const {
+    data: applyDetail,
+    isLoading,
+    isError,
+  } = useQuery<ApplyDetailRes, AxiosError>({
+    queryKey: ["club", "application", applyId],
+    queryFn: () => getApplicationDetail(applyId),
+  });
+  return {
+    applyDetail,
+    isLoading,
     isError,
   };
 };

--- a/app/hooks/apply/useApplyStatusOptions.tsx
+++ b/app/hooks/apply/useApplyStatusOptions.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useRef, useState } from "react";
+import { useState } from "react";
 
 export const useApplyStatusOptions = () => {
   const [isOptionsOpen, setIsOptionsOpen] = useState<boolean>(false); // 지원상태 변경 옵션 드롭다운/바텀시트
@@ -7,27 +7,10 @@ export const useApplyStatusOptions = () => {
   const [isInterviewOpen, setIsInterviewOpen] = useState<boolean>(false); // 면접 확인 메세지 전송 모달
   const [isApplicationOpen, setIsApplicationOpen] = useState<boolean>(false); // 지원서 상세보기 모달
 
-  const optionsRef = useRef<HTMLDivElement>(null);
-
   const handleOptionSelect = (option: string) => {
     setSelectedOption(option);
     setIsModalOpen(true);
   };
-
-  useEffect(() => {
-    const handleClickOutside = (event: MouseEvent) => {
-      if (
-        optionsRef.current &&
-        !optionsRef.current.contains(event.target as Node)
-      ) {
-        setIsOptionsOpen(false);
-      }
-    };
-    document.addEventListener("mousedown", handleClickOutside);
-    return () => {
-      document.removeEventListener("mousedown", handleClickOutside);
-    };
-  }, []);
 
   return {
     isOptionsOpen,
@@ -41,6 +24,5 @@ export const useApplyStatusOptions = () => {
     setIsInterviewOpen,
     isApplicationOpen,
     setIsApplicationOpen,
-    optionsRef,
   };
 };

--- a/app/hooks/apply/useApplyStatusOptions.tsx
+++ b/app/hooks/apply/useApplyStatusOptions.tsx
@@ -1,0 +1,46 @@
+import { useEffect, useRef, useState } from "react";
+
+export const useApplyStatusOptions = () => {
+  const [isOptionsOpen, setIsOptionsOpen] = useState<boolean>(false); // 지원상태 변경 옵션 드롭다운/바텀시트
+  const [selectedOption, setSelectedOption] = useState<string | null>(null);
+  const [isModalOpen, setIsModalOpen] = useState<boolean>(false); // 지원상태 변경 확인 모달
+  const [isInterviewOpen, setIsInterviewOpen] = useState<boolean>(false); // 면접 확인 메세지 전송 모달
+  const [isApplicationOpen, setIsApplicationOpen] = useState<boolean>(false); // 지원서 상세보기 모달
+
+  const optionsRef = useRef<HTMLDivElement>(null);
+
+  const handleOptionSelect = (option: string) => {
+    setSelectedOption(option);
+    setIsModalOpen(true);
+  };
+
+  useEffect(() => {
+    const handleClickOutside = (event: MouseEvent) => {
+      if (
+        optionsRef.current &&
+        !optionsRef.current.contains(event.target as Node)
+      ) {
+        setIsOptionsOpen(false);
+      }
+    };
+    document.addEventListener("mousedown", handleClickOutside);
+    return () => {
+      document.removeEventListener("mousedown", handleClickOutside);
+    };
+  }, []);
+
+  return {
+    isOptionsOpen,
+    setIsOptionsOpen,
+    handleOptionSelect,
+    isModalOpen,
+    setIsModalOpen,
+    selectedOption,
+    setSelectedOption,
+    isInterviewOpen,
+    setIsInterviewOpen,
+    isApplicationOpen,
+    setIsApplicationOpen,
+    optionsRef,
+  };
+};

--- a/app/types/application.ts
+++ b/app/types/application.ts
@@ -137,50 +137,7 @@ export interface ApplyAnswerData {
 export interface ApplyDetailRes {
   applyData: ApplyData;
   applyAnswerDataList: ApplyAnswerData[];
-  fileUri?: string;
-  portfolioUrl?: string;
-}
-
-export interface ApplicationListConditionReq {
-  isPendent: boolean;
-  query?: string;
-  startDateTime?: string;
-  endDateTime?: string;
-}
-
-export interface ApplyAnswerData {
-  body: string;
-  applyQuestionData: {
-    id: string;
-    body: string;
-  };
-}
-
-export type ApplySpecialFieldKeys =
-  | "gender"
-  | "birthday"
-  | "phone"
-  | "email"
-  | "education"
-  | "major"
-  | "occupation"
-  | "mbti"
-  | "availablePeriod"
-  | "preferredActivityField"
-  | "hobby"
-  | "sns"
-  | "motivation"
-  | "activityExperience"
-  | "skill"
-  | "aspiration"
-  | "availableTime"
-  | "referralSource";
-
-// 추가 예정
-export interface ApplyDetailRes {
-  applyData: ApplyData;
-  applyAnswerDataList: ApplyAnswerData[];
-  specialAnswerList: Record<ApplySpecialFieldKeys, string | null>;
+  specialAnswerList: Record<ApplicationKeys, string | null>;
   fileUri?: string;
   portfolioUrl?: string;
 }

--- a/app/types/application.ts
+++ b/app/types/application.ts
@@ -147,3 +147,19 @@ export interface ApplicationListConditionReq {
   startDateTime?: string;
   endDateTime?: string;
 }
+
+export interface ApplyAnswerData {
+  body: string;
+  applyQuestionData: {
+    id: string;
+    body: string;
+  };
+}
+
+// 추가 예정
+export interface ApplyDetailRes {
+  applyData: ApplyData;
+  applyAnswerDataList: ApplyAnswerData[];
+  fileUri?: string;
+  portfolioUrl?: string;
+}

--- a/app/types/application.ts
+++ b/app/types/application.ts
@@ -4,6 +4,7 @@ import { PageInfo } from "./pageInfo";
 import { RecruitmentData } from "./recruitment";
 
 export type ApplyStatusType = "PENDENCY" | "APPROVE" | "REFUSAL" | "INTERVIEW";
+export type AppyStatusText = "대기중" | "합격" | "불합격" | "면접중";
 
 export interface ApplyData {
   id: string;

--- a/app/types/application.ts
+++ b/app/types/application.ts
@@ -156,10 +156,31 @@ export interface ApplyAnswerData {
   };
 }
 
+export type ApplySpecialFieldKeys =
+  | "gender"
+  | "birthday"
+  | "phone"
+  | "email"
+  | "education"
+  | "major"
+  | "occupation"
+  | "mbti"
+  | "availablePeriod"
+  | "preferredActivityField"
+  | "hobby"
+  | "sns"
+  | "motivation"
+  | "activityExperience"
+  | "skill"
+  | "aspiration"
+  | "availableTime"
+  | "referralSource";
+
 // 추가 예정
 export interface ApplyDetailRes {
   applyData: ApplyData;
   applyAnswerDataList: ApplyAnswerData[];
+  specialAnswerList: Record<ApplySpecialFieldKeys, string | null>;
   fileUri?: string;
   portfolioUrl?: string;
 }

--- a/app/types/application.ts
+++ b/app/types/application.ts
@@ -120,6 +120,6 @@ export interface ApplyTempDetailRes {
 export interface ApplicationListConditionReq {
   isPendent: boolean;
   query?: string;
-  startDateTime?: Date;
-  endDateTime?: Date;
+  startDateTime?: string;
+  endDateTime?: string;
 }

--- a/app/types/application.ts
+++ b/app/types/application.ts
@@ -144,6 +144,6 @@ export interface ApplyDetailRes {
 export interface ApplicationListConditionReq {
   isPendent: boolean;
   query?: string;
-  startDateTime?: Date;
-  endDateTime?: Date;
+  startDateTime?: string;
+  endDateTime?: string;
 }

--- a/app/types/application.ts
+++ b/app/types/application.ts
@@ -116,3 +116,10 @@ export interface ApplyTempDetailRes {
   portfolioUrl: string;
   specialAnswerList: SpecialQuestionList;
 }
+
+export interface ApplicationListConditionReq {
+  isPendent: boolean;
+  query?: string;
+  startDateTime?: Date;
+  endDateTime?: Date;
+}

--- a/app/types/application.ts
+++ b/app/types/application.ts
@@ -124,3 +124,19 @@ export interface ApplicationListConditionReq {
   startDateTime?: string;
   endDateTime?: string;
 }
+
+export interface ApplyAnswerData {
+  body: string;
+  applyQuestionData: {
+    id: string;
+    body: string;
+  };
+}
+
+// 추가 예정
+export interface ApplyDetailRes {
+  applyData: ApplyData;
+  applyAnswerDataList: ApplyAnswerData[];
+  fileUri?: string;
+  portfolioUrl?: string;
+}

--- a/app/types/application.ts
+++ b/app/types/application.ts
@@ -140,3 +140,10 @@ export interface ApplyDetailRes {
   fileUri?: string;
   portfolioUrl?: string;
 }
+
+export interface ApplicationListConditionReq {
+  isPendent: boolean;
+  query?: string;
+  startDateTime?: Date;
+  endDateTime?: Date;
+}

--- a/app/utils/dateFormatter.ts
+++ b/app/utils/dateFormatter.ts
@@ -62,3 +62,12 @@ export const formatKoreanTimeOnly = (utcString: string): string => {
 };
 
 export default formatKoreanDate;
+
+/**
+ * LocalDateTime format으로 변환(Z 제거)
+ * @param {Date} date
+ * @returns {string} LocalDateTime string
+ */
+export const formatLocalDateTime = (date: Date): string => {
+  return date.toISOString().slice(0, -1);
+};


### PR DESCRIPTION
## ✅ 주요 작업 사항

동아리 지원 현황
- 동아리 지원현황 리스트 조회(필터링 및 검색, pagination)
- 지원서 상세 조회
- 지원 상태 변경(면접중, 합격, 불합격)
- 지원 상태 변경 옵션 ui + form ui custom hook 생성 및 리팩토링 진행
- 면접 확인 메세지 전송

<br/>

## 🧪 테스트 화면
### 지원 상태 (면접중)으로 변경 + 면접 확인 메세지 전송
![May-03-2025 00-11-05](https://github.com/user-attachments/assets/c420febf-cf21-4cd7-8058-ddd26490c07b)

### 지원 상태 (합격)(불합격)으로 변경
![May-03-2025 00-09-15](https://github.com/user-attachments/assets/88ea8f17-f9d3-4036-b51d-6a464bf71318)


## 📌 참고
- 지원 상태 변경) 면접중 -> 합격으로 변경 시에만 '이미 존재하는 동아리 회원입니다.' 메세지의 에러가 발생하여 백엔드측에 전달드린 상태입니다.