### PR TITLE
[Chore] Query invalidation update

### DIFF
--- a/app/(club)/club/activityHistory/components/activityCreateForm.tsx
+++ b/app/(club)/club/activityHistory/components/activityCreateForm.tsx
@@ -2,6 +2,8 @@
 
 import React, { useState, useEffect, useRef } from "react";
 import useResponsive from "@/hooks/useResponsive";
+import { useQueryClient } from "@tanstack/react-query";
+import { QUERY_KEYS } from "@/constants/queryKeys";
 import ActivityCreateContent from "./activityCreateContent";
 import Alert from "@/components/alert/alert";
 import {
@@ -38,6 +40,7 @@ const ActivityCreateForm = ({
   initialData,
 }: ActivityCreateFormProps) => {
   const isTapOver = useResponsive("md");
+  const queryClient = useQueryClient();
 
   console.log("123123123", clubId);
 
@@ -127,6 +130,8 @@ const ActivityCreateForm = ({
         "업로드 중 오류가 발생했습니다.</br> 잠시 후 다시 시도해 주세요."
       );
       return false;
+    } finally {
+      queryClient.invalidateQueries({ queryKey: [QUERY_KEYS.myClubList] });
     }
   };
 

--- a/app/(club)/club/recruitment/content/clubRecruitmentContent.tsx
+++ b/app/(club)/club/recruitment/content/clubRecruitmentContent.tsx
@@ -15,7 +15,7 @@ import RecruitmentGuideForm from "../components/RecruitmentGuideForm";
 import Alert from "@/components/alert/alert";
 
 import { RecruitmentData } from "@/types/recruitment";
-import { formatKSTTime } from "@/utils/formatKSTTime";
+import { formatTime } from "@/utils/formatKSTTime";
 import { useClubRecruitmentQuery } from "@/hooks/club/recruitment/useClubRecruitmentQuery";
 import { useUserStore } from "@/stores/userStore";
 
@@ -80,10 +80,10 @@ const ClubRecruitmentContent = () => {
                     onClick={() =>
                       router.push(`/recruitment/detail?id=${item.id}`)
                     }
-                    date={`${formatKSTTime(
+                    date={`${formatTime(
                       item.startDateTime,
                       "YYYY.MM.DD"
-                    )} ~ ${formatKSTTime(item.endDateTime, "YYYY.MM.DD")}`}
+                    )} ~ ${formatTime(item.endDateTime, "YYYY.MM.DD")}`}
                     status={item.recruitmentStatusType}
                     isManager={role === "MANAGER" || role === "ADMIN"}
                     setAlertMessage={setAlertMessage}

--- a/app/(recruitment)/recruitment/detail/components/recruitmentSummary.tsx
+++ b/app/(recruitment)/recruitment/detail/components/recruitmentSummary.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { formatKSTTime } from "@/utils/formatKSTTime";
+import { formatTime } from "@/utils/formatKSTTime";
 
 interface RecruitmentSummaryProps {
   members: number;
@@ -23,8 +23,8 @@ const RecruitmentSummary = ({
   endDate,
   procedureType,
 }: RecruitmentSummaryProps) => {
-  const startDateTime = startDate ? formatKSTTime(startDate, "YYYY.MM.DD") : "";
-  const endDateTime = endDate ? formatKSTTime(endDate, "YYYY.MM.DD") : "";
+  const startDateTime = startDate ? formatTime(startDate, "YYYY.MM.DD") : "";
+  const endDateTime = endDate ? formatTime(endDate, "YYYY.MM.DD") : "";
   return (
     <div className="felx text-subtext1 space-y-[14px]">
       <div className="flex flex-row gap-[65px]">

--- a/app/(recruitment)/recruitment/detail/content/clubInfo.tsx
+++ b/app/(recruitment)/recruitment/detail/content/clubInfo.tsx
@@ -66,7 +66,8 @@ const ClubInfo = ({
   const [isBottomModalOpen, setIsBottomModalOpen] = useState<boolean>(false);
   const [alertMessage, setAlertMessage] = useState<string | null>(null);
 
-  const onClubHeartClick = () => {
+  const onClubHeartClick = (e: React.MouseEvent<HTMLDivElement>) => {
+    e.stopPropagation();
     if (!isSignIn) {
       setAlertMessage("로그인 후 이용 가능합니다.");
       return;
@@ -186,6 +187,7 @@ const ClubInfo = ({
                     width={60}
                     height={60}
                     className="relative w-[60px] h-[60px] rounded-full overflow-hidden"
+                    onClick={handleClubClick}
                   />
                   <div
                     className="absolute bottom-0 right-0 cursor-pointer"

--- a/app/(terms)/terms/privacy/page.tsx
+++ b/app/(terms)/terms/privacy/page.tsx
@@ -23,7 +23,7 @@ export const metadata: Metadata = {
   },
 };
 const PrivacyPolicyPage = () => {
-  <MainSection />;
+  return <MainSection />;
 };
 
 export default PrivacyPolicyPage;

--- a/app/(withdrawal)/withdrawal/page.tsx
+++ b/app/(withdrawal)/withdrawal/page.tsx
@@ -43,7 +43,8 @@ const WithDrawal = () => {
   const confirmWithdrawal = async () => {
     try {
       await unregister();
-      await logout();
+      localStorage.removeItem("ariari-auth");
+      localStorage.removeItem("ariari-user-store");
       setCurrentStep(currentStep + 1);
     } catch (error) {
       setIsModalOpen(false);

--- a/app/api/member/api.ts
+++ b/app/api/member/api.ts
@@ -168,6 +168,7 @@ export const getMemberList = async (
     return data;
   } catch (err) {
     console.log("회원 검색 실패", err);
+    throw err;
   }
 };
 
@@ -181,5 +182,6 @@ export const withdrawalClub = async (clubMemberId: string) => {
     return response.status;
   } catch (err) {
     console.log("동아리 회원 탈퇴 실패", err);
+    throw err;
   }
 };

--- a/app/components/bar/floatingBar/recruitmentGuideFloatingBar.tsx
+++ b/app/components/bar/floatingBar/recruitmentGuideFloatingBar.tsx
@@ -5,7 +5,7 @@ import LargeBtn from "@/components/button/basicBtn/largeBtn";
 import WriteBtn from "@/components/button/iconBtn/writeBtn";
 import { useRouter, useSearchParams } from "next/navigation";
 import { useClubActiveRecruitment } from "@/hooks/recruitment/useRecruitmentDetailQuery";
-import { formatKSTTime } from "@/utils/formatKSTTime";
+import { formatTime } from "@/utils/formatKSTTime";
 
 interface DayFloatingBarProps {
   isWriteButtonVisible: boolean;
@@ -48,7 +48,7 @@ const RecruitmentGuideFloatingBar = ({
                   모집 마감까지 남은 시간
                 </p>
                 <h3 className="text-h3 text-text1">
-                  {formatKSTTime(
+                  {formatTime(
                     data.recruitmentData.endDateTime,
                     "MM월 DD일 23:59분 모집 마감"
                   )}

--- a/app/components/card/clubWithdrawalCard.tsx
+++ b/app/components/card/clubWithdrawalCard.tsx
@@ -2,6 +2,13 @@
 
 import { useEffect, useState } from "react";
 import { useRouter, useSearchParams } from "next/navigation";
+import useResponsive from "@/hooks/useResponsive";
+import { useClubContext } from "@/context/ClubContext";
+import {
+  useDeleteClubMutation,
+  useWithdrawClubMutation,
+} from "@/hooks/club/my/useMyClubMutation";
+import { getClubMembers } from "@/api/member/api";
 
 import Image from "next/image";
 import checkIcon from "@/images/icon/radio_button_checked.svg";
@@ -11,16 +18,12 @@ import NoticeCard from "@/components/card/NoticeCard";
 import SmallBtn from "@/components/button/basicBtn/smallBtn";
 import LargeBtn from "@/components/button/basicBtn/largeBtn";
 import MobileSnackBar from "@/components/bar/mobileSnackBar";
-import useResponsive from "@/hooks/useResponsive";
 import NotiPopUp from "@/components/modal/notiPopUp";
 import Alert from "@/components/alert/alert";
 import {
   CLUB_WITHDRAWAL_INFO_GENERAL,
   CLUB_WITHDRAWAL_INFO_MANAGER,
 } from "@/data/withdrawal";
-import { getClubMembers, withdrawalClub } from "@/api/member/api";
-import { useClubContext } from "@/context/ClubContext";
-import { deleteClub } from "@/api/club/api";
 
 interface ClubWithdrawalCardProps {
   isWithdrawal: boolean;
@@ -31,6 +34,8 @@ const ClubWithdrawalCard = ({ isWithdrawal }: ClubWithdrawalCardProps) => {
   const params = useSearchParams();
   const clubId = params.get("clubId") ?? "";
   const { role, clubInfo } = useClubContext();
+  const { mutate: withdrawClub } = useWithdrawClubMutation();
+  const { mutate: deleteClub } = useDeleteClubMutation();
 
   const [isChecked, setIsChecked] = useState<boolean>(false);
   const [showConfirmModal, setShowConfirmModal] = useState<boolean>(false);
@@ -77,7 +82,7 @@ const ClubWithdrawalCard = ({ isWithdrawal }: ClubWithdrawalCardProps) => {
       if (isWithdrawal) {
         // 탈퇴하기
         if (clubInfo?.clubMemberData.id) {
-          withdrawalClub(clubInfo?.clubMemberData.id);
+          withdrawClub(clubInfo?.clubMemberData.id);
         }
       } else {
         // 폐쇄하기
@@ -130,8 +135,8 @@ const ClubWithdrawalCard = ({ isWithdrawal }: ClubWithdrawalCardProps) => {
           />
           <p className="text-mobile_body3_r md:text-body1_r text-primary ">
             {isWithdrawal
-              ? "아리아리 동아리 운영 원칙 제 3조 : 동아리 탈퇴 관련 조항의 내용을 모두 확인하였으며 동의합니다."
-              : "아리아리 동아리 운영 원칙 제 8조 : 동아리 폐쇄 관련 조항의 내용을 모두 확인하였으며 동의합니다."}
+              ? "아리아리 동아리 운영 원칙 : 동아리 탈퇴 관련 조항의 내용을 모두 확인하였으며 동의합니다."
+              : "아리아리 동아리 운영 원칙 : 동아리 폐쇄 관련 조항의 내용을 모두 확인하였으며 동의합니다."}
           </p>
         </div>
         {isMdUp ? (

--- a/app/components/card/myClubCard.tsx
+++ b/app/components/card/myClubCard.tsx
@@ -5,7 +5,7 @@ import defaultImg from "@/images/icon/defaultAriari.svg";
 import { MyClubData } from "@/types/club";
 import { useRouter } from "next/navigation";
 import { formatRelativeTime } from "@/utils/formatRelativeTime";
-import { formatKSTTime } from "@/utils/formatKSTTime";
+import { formatTime } from "@/utils/formatKSTTime";
 
 const getLatestClubDate = (
   club: MyClubData
@@ -54,7 +54,7 @@ const MyClubCard = ({ club }: MyClubCardProps) => {
           <div className="flex gap-1 text-body3_m text-subtext2 whitespace-nowrap ">
             <p>{latest.msg}</p>
             <p>·</p>
-            <p>{formatRelativeTime(formatKSTTime(latest.date))}</p>
+            <p>{formatRelativeTime(formatTime(latest.date))}</p>
           </div>
         )}
       </div>

--- a/app/components/dropdown/clubEventDropdown.tsx
+++ b/app/components/dropdown/clubEventDropdown.tsx
@@ -25,7 +25,7 @@ import AttendanceBottomSheet from "../bottomSheet/attendanceBottomSheet";
 import CommonBottomSheet from "../bottomSheet/commonBottomSheet";
 import { clubMemberRoleType } from "@/types/member";
 import { ClubEventData } from "@/types/clubEvent";
-import { formatKSTTime, formatTime } from "@/utils/formatKSTTime";
+import { formatTime } from "@/utils/formatKSTTime";
 
 const OPTION = [
   { id: 1, label: "수정하기" },

--- a/app/hooks/club/evnet/useClubEventQuery.tsx
+++ b/app/hooks/club/evnet/useClubEventQuery.tsx
@@ -2,7 +2,7 @@ import { AxiosError } from "axios";
 import { useInfiniteQuery } from "@tanstack/react-query";
 import { getClubEventList } from "@/api/club/event/api";
 import { ClubEventListRes } from "@/types/clubEvent";
-import { formatKSTTime } from "@/utils/formatKSTTime";
+import { formatTime } from "@/utils/formatKSTTime";
 // 일정 리스트 조회
 export const useClubEventQuery = (clubId: string) => {
   const { data, fetchNextPage, hasNextPage, isFetchingNextPage, isError } =
@@ -22,7 +22,7 @@ export const useClubEventQuery = (clubId: string) => {
           ...page,
           clubEventDataList: page.clubEventDataList.map((event) => ({
             ...event,
-            eventDateTime: formatKSTTime(event.eventDateTime),
+            eventDateTime: formatTime(event.eventDateTime),
           })),
         })),
       }),

--- a/app/hooks/club/my/useMyClubMutation.tsx
+++ b/app/hooks/club/my/useMyClubMutation.tsx
@@ -1,7 +1,8 @@
 import { useMutation, useQueryClient } from "@tanstack/react-query";
-import { enterClubByInviteKey } from "@/api/club/api";
+import { deleteClub, enterClubByInviteKey } from "@/api/club/api";
 import { QUERY_KEYS } from "@/constants/queryKeys";
 import { EnterClubRes } from "@/types/club";
+import { withdrawalClub } from "@/api/member/api";
 
 interface EnterClubMutationParams {
   inviteKey: string;
@@ -12,7 +13,7 @@ type MyClubMutationProps = {
   onSuccess?: (data: EnterClubRes) => void;
   onError?: (error: Error) => void;
 };
-
+// 동아리 가입
 export const useEnterClubMutation = ({
   onSuccess,
   onError,
@@ -28,6 +29,36 @@ export const useEnterClubMutation = ({
     },
     onError: (error: Error) => {
       onError?.(error);
+    },
+  });
+};
+// 동아리 탈퇴
+export const useWithdrawClubMutation = () => {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: withdrawalClub,
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: [QUERY_KEYS.myClubList] });
+    },
+    onError: (error: Error) => {
+      console.error("동아리 탈퇴 실패:", error);
+      throw error;
+    },
+  });
+};
+// 동아리 폐쇄
+export const useDeleteClubMutation = () => {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: deleteClub,
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: [QUERY_KEYS.myClubList] });
+    },
+    onError: (error: Error) => {
+      console.error("동아리 폐쇄 실패:", error);
+      throw error;
     },
   });
 };

--- a/app/hooks/club/useClubNoticeMutation.tsx
+++ b/app/hooks/club/useClubNoticeMutation.tsx
@@ -3,6 +3,7 @@ import {
   updateClubNotice,
   deleteClubNotice,
 } from "@/api/club/notice/api";
+import { QUERY_KEYS } from "@/constants/queryKeys";
 import { useMutation, useQueryClient } from "@tanstack/react-query";
 
 export const useClubNoticeMutation = ({ clubId }: { clubId: string }) => {
@@ -20,6 +21,7 @@ export const useClubNoticeMutation = ({ clubId }: { clubId: string }) => {
     mutationFn: addClubNotice,
     onSuccess: () => {
       invalidateNoticeQueries(clubId);
+      queryClient.invalidateQueries({ queryKey: [QUERY_KEYS.myClubList] });
     },
     onError: (error) => {
       console.log("add new club notice error", error);


### PR DESCRIPTION
## ✅ 주요 작업 사항
내 동아리 관련
- 동아리 탈퇴/폐쇄 후 myClubList invalidate 처리
- 활동내역/공지사항 작성 후 myClubList invalidate 처리

그 외
- 회원 탈퇴/폐쇄 기능을 React Query mutation으로 변경
- 회원 탈퇴 => 로컬 스토리지 삭제
- KST 보정 삭제
- 동아리 사진 클릭이벤트


## 참고
- 백엔드 측에서 시간 보정하여 저장한다고 하여 보정을 제거하였습니다.
